### PR TITLE
feat: add batch size bytes limit

### DIFF
--- a/pkg/batcher/batcher.go
+++ b/pkg/batcher/batcher.go
@@ -3,8 +3,11 @@ package batcher
 import (
 	"fmt"
 	"math"
+	"reflect"
 	"sync"
+	"sync/atomic"
 	"time"
+	"unsafe"
 
 	"github.com/destel/rill"
 	"golang.design/x/chann"
@@ -19,38 +22,45 @@ func NoOpProcessor[T any]([]T) error {
 }
 
 type Config[T any] struct {
-	SkipAutoStart bool
-	BatchSize     int
-	BatchInterval time.Duration
-	Concurrency   int
-	ProcessorFunc Processor[T]
+	SkipAutoStart  bool
+	BatchSize      int
+	BatchInterval  time.Duration
+	Concurrency    int
+	ProcessorFunc  Processor[T]
+	BatchSizeBytes int64
 }
 
 type Batcher[T any] struct {
 	config *Config[T]
 
-	isClosed       bool
-	closeOnce      sync.Once
-	itemCount      *AtomicCounter
-	doneChan       chan struct{}
-	errorsChan     *chann.Chann[error]
-	batchInputChan *chann.Chann[rill.Try[T]]
-	batchesChan    <-chan rill.Try[[]T]
+	isClosed    uint32
+	closeOnce   sync.Once
+	itemCount   *AtomicCounter
+	doneChan    chan struct{}
+	errorsChan  *chann.Chann[error]
+	batchesChan chan rill.Try[[]T]
+
+	currentBatch     []T
+	currentBatchSize int64
+	batchMutex       sync.Mutex
+	batchTimer       *time.Timer
 }
 
 // New creates a new Batcher with the given options.
 func New[T any](options ...Option[T]) *Batcher[T] {
 	b := &Batcher[T]{
 		config: &Config[T]{
-			BatchSize:     DefaultBatchSize,
-			BatchInterval: DefaultBatchInterval,
-			Concurrency:   DefaultConcurrency,
-			ProcessorFunc: NoOpProcessor[T],
+			BatchSize:      DefaultBatchSize,
+			BatchInterval:  DefaultBatchInterval,
+			Concurrency:    DefaultConcurrency,
+			ProcessorFunc:  NoOpProcessor[T],
+			BatchSizeBytes: DefaultBatchSizeBytes,
 		},
 
-		itemCount:      NewAtomicCounter(),
-		doneChan:       make(chan struct{}),
-		batchInputChan: chann.New[rill.Try[T]](chann.Cap(-1)),
+		itemCount:    NewAtomicCounter(),
+		doneChan:     make(chan struct{}),
+		batchesChan:  make(chan rill.Try[[]T], 10),
+		currentBatch: make([]T, 0, DefaultBatchSize),
 	}
 
 	for _, option := range options {
@@ -59,11 +69,8 @@ func New[T any](options ...Option[T]) *Batcher[T] {
 
 	b.errorsChan = chann.New[error](chann.Cap(-1))
 
-	batchOutput := rill.Batch(b.batchInputChan.Out(), b.config.BatchSize, b.config.BatchInterval)
-	b.batchesChan = batchOutput
-
 	if !b.config.SkipAutoStart {
-		b.Start()
+		go b.startProcessing()
 	}
 
 	return b
@@ -78,8 +85,157 @@ func (b *Batcher[T]) Config() *Config[T] {
 }
 
 func (b *Batcher[T]) Add(item T) {
-	b.batchInputChan.In() <- rill.Try[T]{Value: item}
+	if atomic.LoadUint32(&b.isClosed) != 0 {
+		return
+	}
+
+	itemSize := b.CalculateItemSize(item)
+
+	b.batchMutex.Lock()
+	defer b.batchMutex.Unlock()
+
+	if atomic.LoadUint32(&b.isClosed) != 0 {
+		return
+	}
+
+	shouldFlush := len(b.currentBatch) >= b.config.BatchSize ||
+		b.currentBatchSize+itemSize >= b.config.BatchSizeBytes
+
+	if shouldFlush && len(b.currentBatch) > 0 {
+		b.flushCurrentBatch()
+	}
+
+	b.currentBatch = append(b.currentBatch, item)
+	b.currentBatchSize += itemSize
 	b.itemCount.Add(1)
+
+	if b.batchTimer == nil && len(b.currentBatch) == 1 {
+		var timer *time.Timer
+		timer = time.AfterFunc(b.config.BatchInterval, func() {
+			b.flushBatchOnTimer(timer)
+		})
+
+		b.batchTimer = timer
+	}
+}
+
+func (b *Batcher[T]) CalculateItemSize(item T) int64 {
+	v := reflect.ValueOf(item)
+	visited := make(map[uintptr]bool)
+	return int64(b.sizeOfWithVisited(v, visited))
+}
+
+func (b *Batcher[T]) sizeOfWithVisited(v reflect.Value, visited map[uintptr]bool) uintptr {
+	switch v.Kind() {
+	case reflect.String:
+		return unsafe.Sizeof("") + uintptr(v.Len())
+
+	case reflect.Slice:
+		if v.IsNil() {
+			return unsafe.Sizeof([]int{})
+		}
+
+		addr := v.Pointer()
+		if visited[addr] {
+			return unsafe.Sizeof([]int{})
+		}
+		visited[addr] = true
+
+		elemSize := uintptr(0)
+		if v.Len() > 0 {
+			elemSize = b.sizeOfWithVisited(v.Index(0), visited)
+		}
+
+		return unsafe.Sizeof([]int{}) + uintptr(v.Len())*elemSize
+
+	case reflect.Map:
+		if v.IsNil() {
+			return unsafe.Sizeof(map[int]int{})
+		}
+
+		addr := v.Pointer()
+		if visited[addr] {
+			return unsafe.Sizeof(map[int]int{})
+		}
+		visited[addr] = true
+
+		size := unsafe.Sizeof(map[int]int{})
+		for _, key := range v.MapKeys() {
+			size += b.sizeOfWithVisited(key, visited) + b.sizeOfWithVisited(v.MapIndex(key), visited)
+		}
+
+		return size
+
+	case reflect.Struct:
+		size := uintptr(0)
+		for i := 0; i < v.NumField(); i++ {
+			size += b.sizeOfWithVisited(v.Field(i), visited)
+		}
+
+		return size
+
+	case reflect.Ptr:
+		if v.IsNil() {
+			return unsafe.Sizeof(uintptr(0))
+		}
+
+		addr := v.Pointer()
+		if visited[addr] {
+			return unsafe.Sizeof(uintptr(0))
+		}
+		visited[addr] = true
+
+		return unsafe.Sizeof(uintptr(0)) + b.sizeOfWithVisited(v.Elem(), visited)
+
+	default:
+		return v.Type().Size()
+	}
+}
+
+func (b *Batcher[T]) flushBatchOnTimer(timer *time.Timer) {
+	b.batchMutex.Lock()
+	defer b.batchMutex.Unlock()
+
+	if atomic.LoadUint32(&b.isClosed) != 0 {
+		return
+	}
+
+	if b.batchTimer == timer && len(b.currentBatch) > 0 {
+		b.flushCurrentBatch()
+	}
+}
+
+func (b *Batcher[T]) flushCurrentBatch() {
+	if atomic.LoadUint32(&b.isClosed) != 0 {
+		return
+	}
+
+	if len(b.currentBatch) == 0 {
+		return
+	}
+
+	batch := make([]T, len(b.currentBatch))
+	copy(batch, b.currentBatch)
+
+	select {
+	case <-b.doneChan:
+		return
+	default:
+	}
+
+	select {
+	case b.batchesChan <- rill.Try[[]T]{Value: batch}:
+	case <-b.doneChan:
+		return
+	}
+
+	b.currentBatch = b.currentBatch[:0]
+	b.currentBatchSize = 0
+
+	if b.batchTimer != nil {
+		b.batchTimer.Stop()
+		b.batchTimer = nil
+	}
 }
 
 func (b *Batcher[T]) Len() int {
@@ -102,7 +258,7 @@ func (b *Batcher[T]) Join(timeout time.Duration) error {
 
 func (b *Batcher[T]) startProcessing() {
 	defer b.errorsChan.Close()
-	defer b.batchInputChan.Close()
+	defer close(b.batchesChan)
 
 	for {
 		select {
@@ -111,7 +267,6 @@ func (b *Batcher[T]) startProcessing() {
 		case batch := <-b.batchesChan:
 			if batch.Error != nil {
 				b.errorsChan.In() <- batch.Error
-
 				continue
 			}
 
@@ -132,18 +287,23 @@ func (b *Batcher[T]) Close() error {
 	var clErr error
 
 	b.closeOnce.Do(func() {
+		b.batchMutex.Lock()
+		if len(b.currentBatch) > 0 {
+			b.flushCurrentBatch()
+		}
+		b.batchMutex.Unlock()
+
 		timeout := time.Duration(2*2*math.Ceil(float64(b.Len())/float64(b.config.BatchSize))) *
 			b.config.BatchInterval
 		clErr = b.Join(timeout)
 
+		atomic.StoreUint32(&b.isClosed, 1)
 		close(b.doneChan)
-
-		b.isClosed = true
 	})
 
 	return clErr
 }
 
 func (b *Batcher[T]) IsClosed() bool {
-	return b.isClosed
+	return atomic.LoadUint32(&b.isClosed) != 0
 }

--- a/pkg/batcher/batcher_test.go
+++ b/pkg/batcher/batcher_test.go
@@ -230,3 +230,376 @@ func TestFlushOnClose(t *testing.T) {
 		require.True(t, ok)
 	}
 }
+
+func TestCanSetBatchSizeBytes(t *testing.T) {
+	// ARRANGE & ACT
+	b := batcher.New(
+		batcher.WithBatchSizeBytes[test.BatchItem](1024),
+	)
+
+	// ASSERT
+	require.Equal(t, int64(1024), b.Config().BatchSizeBytes)
+}
+
+func TestFlushesWhenByteLimitReached(t *testing.T) {
+	// ARRANGE
+	var processedBatches [][]test.BatchItem
+	var mu sync.Mutex
+
+	b := batcher.New(
+		batcher.WithBatchSizeBytes[test.BatchItem](100),
+		batcher.WithBatchSize[test.BatchItem](1000),
+		batcher.WithBatchInterval[test.BatchItem](1*time.Second),
+		batcher.WithProcessor(func(items []test.BatchItem) error {
+			mu.Lock()
+			defer mu.Unlock()
+			processedBatches = append(processedBatches, items)
+			return nil
+		}),
+	)
+
+	// ACT
+	for i := 0; i < 10; i++ {
+		b.Add(test.BatchItem{Key: fmt.Sprintf("very_long_key_that_should_exceed_byte_limit_%d", i)})
+	}
+
+	// ASSERT
+	require.NoError(t, b.Join(200*time.Millisecond))
+
+	require.Greater(t, len(processedBatches), 1, "Should have created multiple batches due to byte limit")
+
+	totalItems := 0
+	for _, batch := range processedBatches {
+		totalItems += len(batch)
+	}
+	require.Equal(t, 10, totalItems, "All items should be processed")
+}
+
+func TestRespectsItemCountLimitWithByteLimit(t *testing.T) {
+	// ARRANGE
+	var processedBatches [][]test.BatchItem
+	var mu sync.Mutex
+
+	b := batcher.New(
+		batcher.WithBatchSizeBytes[test.BatchItem](10000),
+		batcher.WithBatchSize[test.BatchItem](3),
+		batcher.WithBatchInterval[test.BatchItem](1*time.Second),
+		batcher.WithProcessor(func(items []test.BatchItem) error {
+			mu.Lock()
+			defer mu.Unlock()
+			processedBatches = append(processedBatches, items)
+			return nil
+		}),
+	)
+
+	// ACT
+	for i := 0; i < 10; i++ {
+		b.Add(test.BatchItem{Key: fmt.Sprintf("key_%d", i)})
+	}
+
+	// ASSERT
+	require.NoError(t, b.Join(200*time.Millisecond))
+
+	require.Greater(t, len(processedBatches), 1, "Should have created multiple batches due to item count limit")
+
+	for i, batch := range processedBatches[:len(processedBatches)-1] {
+		require.LessOrEqual(t, len(batch), 3, "Batch %d should not exceed item count limit", i)
+	}
+
+	totalItems := 0
+	for _, batch := range processedBatches {
+		totalItems += len(batch)
+	}
+	require.Equal(t, 10, totalItems, "All items should be processed")
+}
+
+func TestHandlesLargeItemsCorrectly(t *testing.T) {
+	// ARRANGE
+	var processedBatches [][]test.BatchItem
+	var mu sync.Mutex
+
+	b := batcher.New(
+		batcher.WithBatchSizeBytes[test.BatchItem](50),
+		batcher.WithBatchSize[test.BatchItem](100),
+		batcher.WithBatchInterval[test.BatchItem](1*time.Second),
+		batcher.WithProcessor(func(items []test.BatchItem) error {
+			mu.Lock()
+			defer mu.Unlock()
+			processedBatches = append(processedBatches, items)
+			return nil
+		}),
+	)
+
+	// ACT
+	largeKey := fmt.Sprintf("this_is_a_very_large_key_that_exceeds_the_byte_limit_%s",
+		"padding_to_make_it_even_larger_and_ensure_single_item_batches")
+
+	for i := 0; i < 5; i++ {
+		b.Add(test.BatchItem{Key: fmt.Sprintf("%s_%d", largeKey, i)})
+	}
+
+	// ASSERT
+	require.NoError(t, b.Join(200*time.Millisecond))
+
+	require.Equal(t, 5, len(processedBatches), "Should create one batch per large item")
+
+	for i, batch := range processedBatches {
+		require.Equal(t, 1, len(batch), "Batch %d should contain exactly one large item", i)
+	}
+}
+
+func TestCalculatesStringSizeCorrectly(t *testing.T) {
+	// ARRANGE
+	b := batcher.New[string]()
+
+	// ACT & ASSERT
+	shortString := "hello"
+	longString := "this is a much longer string that should have a larger calculated size"
+
+	shortSize := b.CalculateItemSize(shortString)
+	longSize := b.CalculateItemSize(longString)
+
+	require.Greater(t, longSize, shortSize, "Longer string should have larger calculated size")
+	require.Greater(t, shortSize, int64(0), "String size should be positive")
+}
+
+func TestCalculatesStructSizeCorrectly(t *testing.T) {
+	// ARRANGE
+	type TestStruct struct {
+		Name        string
+		Value       int
+		Description string
+	}
+
+	b := batcher.New[TestStruct]()
+
+	// ACT & ASSERT
+	smallStruct := TestStruct{Name: "a", Value: 1, Description: "b"}
+	largeStruct := TestStruct{
+		Name:        "very_long_name_field",
+		Value:       12345,
+		Description: "this is a very long description field that should make the struct larger",
+	}
+
+	smallSize := b.CalculateItemSize(smallStruct)
+	largeSize := b.CalculateItemSize(largeStruct)
+
+	require.Greater(t, largeSize, smallSize, "Larger struct should have larger calculated size")
+	require.Greater(t, smallSize, int64(0), "Struct size should be positive")
+}
+
+func TestCalculatesSliceSizeCorrectly(t *testing.T) {
+	// ARRANGE
+	b := batcher.New[[]string]()
+
+	// ACT & ASSERT
+	smallSlice := []string{"a", "b"}
+	largeSlice := []string{"longer", "slice", "with", "more", "elements", "and", "longer", "strings"}
+
+	smallSize := b.CalculateItemSize(smallSlice)
+	largeSize := b.CalculateItemSize(largeSlice)
+
+	require.Greater(t, largeSize, smallSize, "Larger slice should have larger calculated size")
+	require.Greater(t, smallSize, int64(0), "Slice size should be positive")
+}
+
+func TestCalculatesMapSizeCorrectly(t *testing.T) {
+	// ARRANGE
+	b := batcher.New[map[string]int]()
+
+	// ACT & ASSERT
+	smallMap := map[string]int{"a": 1, "b": 2}
+	largeMap := map[string]int{
+		"longer_key_1": 100,
+		"longer_key_2": 200,
+		"longer_key_3": 300,
+		"longer_key_4": 400,
+		"longer_key_5": 500,
+	}
+
+	smallSize := b.CalculateItemSize(smallMap)
+	largeSize := b.CalculateItemSize(largeMap)
+
+	require.Greater(t, largeSize, smallSize, "Larger map should have larger calculated size")
+	require.Greater(t, smallSize, int64(0), "Map size should be positive")
+}
+
+func TestFlushesAfterTimeoutWithByteLimit(t *testing.T) {
+	// ARRANGE
+	var processedBatches [][]test.BatchItem
+	var mu sync.Mutex
+
+	b := batcher.New(
+		batcher.WithBatchSizeBytes[test.BatchItem](10000),
+		batcher.WithBatchSize[test.BatchItem](1000),
+		batcher.WithBatchInterval[test.BatchItem](50*time.Millisecond),
+		batcher.WithProcessor(func(items []test.BatchItem) error {
+			mu.Lock()
+			defer mu.Unlock()
+			processedBatches = append(processedBatches, items)
+			return nil
+		}),
+	)
+
+	// ACT
+	b.Add(test.BatchItem{Key: "item1"})
+	b.Add(test.BatchItem{Key: "item2"})
+
+	time.Sleep(100 * time.Millisecond)
+
+	// ASSERT
+	require.Equal(t, 1, len(processedBatches), "Should have flushed one batch due to timeout")
+	require.Equal(t, 2, len(processedBatches[0]), "Batch should contain both items")
+}
+
+func TestHandlesConcurrentAddsWithByteLimits(t *testing.T) {
+	// ARRANGE
+	var processedItems sync.Map
+
+	b := batcher.New(
+		batcher.WithBatchSizeBytes[test.BatchItem](200),
+		batcher.WithBatchSize[test.BatchItem](50),
+		batcher.WithBatchInterval[test.BatchItem](10*time.Millisecond),
+		batcher.WithProcessor(func(items []test.BatchItem) error {
+			for _, item := range items {
+				processedItems.Store(item.Key, true)
+			}
+			return nil
+		}),
+	)
+
+	// ACT
+	var wg sync.WaitGroup
+	numGoroutines := 10
+	itemsPerGoroutine := 100
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(goroutineID int) {
+			defer wg.Done()
+			for j := 0; j < itemsPerGoroutine; j++ {
+				key := fmt.Sprintf("goroutine_%d_item_%d", goroutineID, j)
+				b.Add(test.BatchItem{Key: key})
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// ASSERT
+	require.NoError(t, b.Join(500*time.Millisecond))
+
+	expectedTotal := numGoroutines * itemsPerGoroutine
+	actualTotal := 0
+	processedItems.Range(func(_, _ interface{}) bool {
+		actualTotal++
+		return true
+	})
+
+	require.Equal(t, expectedTotal, actualTotal, "All items should be processed exactly once")
+}
+
+func TestHandlesZeroByteLimit(t *testing.T) {
+	// ARRANGE
+	var processedBatches [][]test.BatchItem
+	var mu sync.Mutex
+
+	b := batcher.New(
+		batcher.WithBatchSizeBytes[test.BatchItem](0),
+		batcher.WithBatchSize[test.BatchItem](10),
+		batcher.WithBatchInterval[test.BatchItem](50*time.Millisecond),
+		batcher.WithProcessor(func(items []test.BatchItem) error {
+			mu.Lock()
+			defer mu.Unlock()
+			processedBatches = append(processedBatches, items)
+			return nil
+		}),
+	)
+
+	// ACT
+	for i := 0; i < 5; i++ {
+		b.Add(test.BatchItem{Key: fmt.Sprintf("key_%d", i)})
+	}
+
+	// ASSERT
+	require.NoError(t, b.Join(200*time.Millisecond))
+
+	totalItems := 0
+	for _, batch := range processedBatches {
+		totalItems += len(batch)
+	}
+	require.Equal(t, 5, totalItems, "All items should be processed despite zero byte limit")
+}
+
+func TestHandlesEmptyItems(t *testing.T) {
+	// ARRANGE
+	var processedBatches [][]test.BatchItem
+	var mu sync.Mutex
+
+	b := batcher.New(
+		batcher.WithBatchSizeBytes[test.BatchItem](100),
+		batcher.WithBatchSize[test.BatchItem](10),
+		batcher.WithBatchInterval[test.BatchItem](50*time.Millisecond),
+		batcher.WithProcessor(func(items []test.BatchItem) error {
+			mu.Lock()
+			defer mu.Unlock()
+			processedBatches = append(processedBatches, items)
+			return nil
+		}),
+	)
+
+	// ACT
+	for i := 0; i < 5; i++ {
+		b.Add(test.BatchItem{Key: ""})
+	}
+
+	// ASSERT
+	require.NoError(t, b.Join(200*time.Millisecond))
+
+	totalItems := 0
+	for _, batch := range processedBatches {
+		totalItems += len(batch)
+	}
+	require.Equal(t, 5, totalItems, "All empty items should be processed")
+}
+
+func TestTimerDoesNotFlushWrongBatch(t *testing.T) {
+	// ARRANGE
+	var processedBatches [][]test.BatchItem
+	var mu sync.Mutex
+
+	b := batcher.New(
+		batcher.WithBatchSizeBytes[test.BatchItem](50),
+		batcher.WithBatchSize[test.BatchItem](100),
+		batcher.WithBatchInterval[test.BatchItem](100*time.Millisecond),
+		batcher.WithProcessor(func(items []test.BatchItem) error {
+			mu.Lock()
+			defer mu.Unlock()
+			processedBatches = append(processedBatches, items)
+			return nil
+		}),
+	)
+
+	// ACT
+	b.Add(test.BatchItem{Key: "item1"})
+
+	time.Sleep(50 * time.Millisecond)
+
+	b.Add(test.BatchItem{Key: "very_long_key_that_should_trigger_byte_limit_flush_immediately"})
+
+	time.Sleep(80 * time.Millisecond)
+
+	b.Add(test.BatchItem{Key: "item3"})
+
+	time.Sleep(150 * time.Millisecond)
+
+	// ASSERT
+	require.Equal(t, 3, len(processedBatches), "Should have exactly 3 batches")
+	require.Equal(t, 1, len(processedBatches[0]), "First batch should have 1 item (timer flush)")
+	require.Equal(t, 1, len(processedBatches[1]), "Second batch should have 1 item (byte limit flush)")
+	require.Equal(t, 1, len(processedBatches[2]), "Third batch should have 1 item (timer flush)")
+
+	require.Equal(t, "item1", processedBatches[0][0].Key)
+	require.Contains(t, processedBatches[1][0].Key, "very_long_key")
+	require.Equal(t, "item3", processedBatches[2][0].Key)
+}

--- a/pkg/batcher/constants.go
+++ b/pkg/batcher/constants.go
@@ -11,4 +11,7 @@ const (
 
 	// DefaultConcurrency is the default concurrency.
 	DefaultConcurrency = 3
+
+	// DefaultBatchSizeBytes is the default batch size in bytes.
+	DefaultBatchSizeBytes = 10 * 1024 * 1024 // 10MB
 )

--- a/pkg/batcher/options.go
+++ b/pkg/batcher/options.go
@@ -41,3 +41,14 @@ func WithSkipAutoStart[T any]() Option[T] {
 		b.config.SkipAutoStart = true
 	}
 }
+
+// WithBatchSizeBytes sets the batch size in bytes.
+func WithBatchSizeBytes[T any](batchSizeBytes int64) Option[T] {
+	return func(b *Batcher[T]) {
+		if batchSizeBytes <= 0 {
+			batchSizeBytes = DefaultBatchSizeBytes
+		}
+
+		b.config.BatchSizeBytes = batchSizeBytes
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for batching based on both item count and total byte size, with a new configuration option to set the maximum batch size in bytes.
  - Introduced a default batch size limit of 10 MB.
  - Provided an option to customize the batch size in bytes.
  - Added option to disable automatic batcher start for manual control.

- **Bug Fixes**
  - Improved batch flushing logic to ensure batches are processed correctly when byte or count limits are reached, or after a timeout.

- **Tests**
  - Added comprehensive tests to verify correct batching behavior with byte size limits, including edge cases and concurrent operations.

- **Documentation**
  - Updated README to document new batch size control option and manual start option.
  - Clarified batch flushing conditions and option descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->