### PR TITLE
feat: close stale prs

### DIFF
--- a/.github/workflows/stale-prs.yaml
+++ b/.github/workflows/stale-prs.yaml
@@ -1,0 +1,31 @@
+name: "Close stale PRs"
+on:
+  schedule:
+    - cron: "45 * * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: write # only for delete-branch option
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: stale
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5.1.1
+        with:
+          stale-pr-message: "This has been automatically marked as stale because it has not had recent activity, and will be closed if no further activity occurs. If this was overlooked, forgotten, or should remain open for any other reason, please reply here to call attention to it and remove the stale status. Thank you for your contributions."
+          close-pr-message: "This has been automatically closed because it has not had recent activity. Please feel free to update or reopen it."
+          stale-pr-label: "stale"
+          remove-pr-stale-when-updated: "true"
+          days-before-stale: 30
+          days-before-close: 7
+          operations-per-run: 200
+          ascending: "true"
+          enable-statistics: "true"
+          delete-branch: "true"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced automated management of stale pull requests. Inactive pull requests are now marked as stale after 30 days and closed after an additional 7 days of inactivity. Associated branches are deleted upon closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->