### PR TITLE
feat: add WithMaxQueueSize for bounded queue backpressure

### DIFF
--- a/pkg/batcher/batcher.go
+++ b/pkg/batcher/batcher.go
@@ -23,6 +23,7 @@ type Config[T any] struct {
 	BatchSize     int
 	BatchInterval time.Duration
 	Concurrency   int
+	MaxQueueSize  int
 	ProcessorFunc Processor[T]
 }
 
@@ -48,15 +49,20 @@ func New[T any](options ...Option[T]) *Batcher[T] {
 			ProcessorFunc: NoOpProcessor[T],
 		},
 
-		itemCount:      NewAtomicCounter(),
-		doneChan:       make(chan struct{}),
-		batchInputChan: chann.New[rill.Try[T]](chann.Cap(-1)),
+		itemCount: NewAtomicCounter(),
+		doneChan:  make(chan struct{}),
 	}
 
 	for _, option := range options {
 		option(b)
 	}
 
+	queueCap := chann.Cap(-1) // unbounded by default
+	if b.config.MaxQueueSize > 0 {
+		queueCap = chann.Cap(b.config.MaxQueueSize)
+	}
+
+	b.batchInputChan = chann.New[rill.Try[T]](queueCap)
 	b.errorsChan = chann.New[error](chann.Cap(-1))
 
 	batchOutput := rill.Batch(b.batchInputChan.Out(), b.config.BatchSize, b.config.BatchInterval)

--- a/pkg/batcher/batcher.go
+++ b/pkg/batcher/batcher.go
@@ -34,10 +34,11 @@ type Batcher[T any] struct {
 	closeOnce      sync.Once
 	itemCount      *AtomicCounter
 	doneChan       chan struct{}
+	closingChan    chan struct{} // closed at start of Close(); unblocks Add()
 	errorsChan     *chann.Chann[error]
 	batchInputChan *chann.Chann[rill.Try[T]]
 	batchesChan    <-chan rill.Try[[]T]
-	queueSemaphore chan struct{} // nil when unbounded
+	queueSemaphore chan struct{}
 }
 
 // New creates a new Batcher with the given options.
@@ -50,8 +51,9 @@ func New[T any](options ...Option[T]) *Batcher[T] {
 			ProcessorFunc: NoOpProcessor[T],
 		},
 
-		itemCount: NewAtomicCounter(),
-		doneChan:  make(chan struct{}),
+		itemCount:   NewAtomicCounter(),
+		doneChan:    make(chan struct{}),
+		closingChan: make(chan struct{}),
 	}
 
 	for _, option := range options {
@@ -85,7 +87,11 @@ func (b *Batcher[T]) Config() *Config[T] {
 
 func (b *Batcher[T]) Add(item T) {
 	if b.queueSemaphore != nil {
-		b.queueSemaphore <- struct{}{} // blocks when queue is full
+		select {
+		case b.queueSemaphore <- struct{}{}:
+		case <-b.closingChan:
+			return
+		}
 	}
 
 	b.batchInputChan.In() <- rill.Try[T]{Value: item}
@@ -148,6 +154,8 @@ func (b *Batcher[T]) Close() error {
 	var clErr error
 
 	b.closeOnce.Do(func() {
+		close(b.closingChan) // unblock any waiting Add() callers immediately
+
 		timeout := time.Duration(2*2*math.Ceil(float64(b.Len())/float64(b.config.BatchSize))) *
 			b.config.BatchInterval
 		clErr = b.Join(timeout)

--- a/pkg/batcher/batcher.go
+++ b/pkg/batcher/batcher.go
@@ -37,6 +37,7 @@ type Batcher[T any] struct {
 	errorsChan     *chann.Chann[error]
 	batchInputChan *chann.Chann[rill.Try[T]]
 	batchesChan    <-chan rill.Try[[]T]
+	queueSemaphore chan struct{} // nil when unbounded
 }
 
 // New creates a new Batcher with the given options.
@@ -57,12 +58,11 @@ func New[T any](options ...Option[T]) *Batcher[T] {
 		option(b)
 	}
 
-	queueCap := chann.Cap(-1) // unbounded by default
-	if b.config.MaxQueueSize > 0 {
-		queueCap = chann.Cap(b.config.MaxQueueSize)
-	}
+	b.batchInputChan = chann.New[rill.Try[T]](chann.Cap(-1))
 
-	b.batchInputChan = chann.New[rill.Try[T]](queueCap)
+	if b.config.MaxQueueSize > 0 {
+		b.queueSemaphore = make(chan struct{}, b.config.MaxQueueSize)
+	}
 	b.errorsChan = chann.New[error](chann.Cap(-1))
 
 	batchOutput := rill.Batch(b.batchInputChan.Out(), b.config.BatchSize, b.config.BatchInterval)
@@ -84,6 +84,10 @@ func (b *Batcher[T]) Config() *Config[T] {
 }
 
 func (b *Batcher[T]) Add(item T) {
+	if b.queueSemaphore != nil {
+		b.queueSemaphore <- struct{}{} // blocks when queue is full
+	}
+
 	b.batchInputChan.In() <- rill.Try[T]{Value: item}
 	b.itemCount.Add(1)
 }
@@ -126,6 +130,12 @@ func (b *Batcher[T]) startProcessing() {
 			}
 
 			b.itemCount.Add(int64(-len(batch.Value)))
+
+			if b.queueSemaphore != nil {
+				for range len(batch.Value) {
+					<-b.queueSemaphore
+				}
+			}
 		}
 	}
 }

--- a/pkg/batcher/batcher_test.go
+++ b/pkg/batcher/batcher_test.go
@@ -306,6 +306,48 @@ func TestMaxQueueSizeDefaultIsUnbounded(t *testing.T) {
 	require.EqualValues(t, 10000, processed.Load())
 }
 
+func TestMaxQueueSizeAddUnblocksOnClose(t *testing.T) {
+	// ARRANGE — processor blocks forever, queue fills up, Add blocks
+	b := batcher.New(
+		batcher.WithBatchSize[test.BatchItem](2),
+		batcher.WithBatchInterval[test.BatchItem](10*time.Second),
+		batcher.WithMaxQueueSize[test.BatchItem](4),
+		batcher.WithProcessor(func(_ []test.BatchItem) error {
+			select {} // block forever — simulates hung processor
+		}),
+	)
+
+	// Fill the queue
+	for i := 0; i < 4; i++ {
+		b.Add(test.BatchItem{Key: fmt.Sprintf("key_%d", i)})
+	}
+
+	// Add blocks because queue is full and processor never releases
+	addReturned := make(chan struct{})
+	go func() {
+		b.Add(test.BatchItem{Key: "blocked"})
+		close(addReturned)
+	}()
+
+	// Verify it's actually blocked
+	select {
+	case <-addReturned:
+		t.Fatal("Add returned before Close — expected it to block")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// ACT — Close the batcher, which should unblock the stuck Add
+	go b.Close()
+
+	// ASSERT — Add must return promptly after Close
+	select {
+	case <-addReturned:
+		// Good — Add unblocked on shutdown
+	case <-time.After(1 * time.Second):
+		t.Fatal("Add still blocked after Close — deadlock")
+	}
+}
+
 func TestMaxQueueSizeZeroIsIgnored(t *testing.T) {
 	// ARRANGE
 	b := batcher.New(

--- a/pkg/batcher/batcher_test.go
+++ b/pkg/batcher/batcher_test.go
@@ -233,43 +233,52 @@ func TestFlushOnClose(t *testing.T) {
 }
 
 func TestMaxQueueSizeBlocksWhenFull(t *testing.T) {
-	// ARRANGE — slow processor to keep the queue full
+	// ARRANGE — processor blocks until we release it, keeping the queue full
+	processorGate := make(chan struct{})
+
 	b := batcher.New(
 		batcher.WithBatchSize[test.BatchItem](2),
 		batcher.WithBatchInterval[test.BatchItem](10*time.Second),
 		batcher.WithMaxQueueSize[test.BatchItem](4),
 		batcher.WithProcessor(func(_ []test.BatchItem) error {
-			time.Sleep(50 * time.Millisecond) // slow processor
+			<-processorGate // block until test releases
 			return nil
 		}),
 	)
 	defer b.Close()
 
-	// ACT — fill the queue (4 items = queue cap)
+	// ACT — fill the queue to capacity
 	for i := 0; i < 4; i++ {
 		b.Add(test.BatchItem{Key: fmt.Sprintf("key_%d", i)})
 	}
 
-	// The 5th Add should block because the queue is full.
-	// Use a goroutine with a timeout to verify it blocks.
-	done := make(chan struct{})
+	// The 5th Add must block because the queue is full and the processor is
+	// held. We verify by checking it has NOT completed after 100ms.
+	addCompleted := make(chan struct{})
 	go func() {
 		b.Add(test.BatchItem{Key: "blocked"})
-		close(done)
+		close(addCompleted)
 	}()
 
 	select {
-	case <-done:
-		// If Add returns immediately, the queue didn't block — that's wrong
-		// unless the processor already drained items. Give a small window.
-		// If it returns within 5ms, the queue likely isn't blocking.
-		t.Log("Add returned quickly — processor may have drained the queue, which is acceptable")
-	case <-time.After(20 * time.Millisecond):
-		// Add blocked for 20ms — the queue is applying backpressure. Good.
+	case <-addCompleted:
+		t.Fatal("Add returned immediately — expected it to block on a full queue")
+	case <-time.After(100 * time.Millisecond):
+		// Good — Add is blocked.
 	}
 
-	// ASSERT — eventually all items are processed
-	require.NoError(t, b.Join(500*time.Millisecond))
+	// Release the processor so it drains items and unblocks Add.
+	close(processorGate)
+
+	select {
+	case <-addCompleted:
+		// Good — Add completed after processor drained the queue.
+	case <-time.After(1 * time.Second):
+		t.Fatal("Add still blocked after processor was released")
+	}
+
+	// ASSERT — all items are eventually processed
+	require.NoError(t, b.Join(1*time.Second))
 	require.Equal(t, 0, b.Len())
 }
 

--- a/pkg/batcher/batcher_test.go
+++ b/pkg/batcher/batcher_test.go
@@ -232,6 +232,82 @@ func TestFlushOnClose(t *testing.T) {
 	}
 }
 
+func TestMaxQueueSizeBlocksWhenFull(t *testing.T) {
+	// ARRANGE — slow processor to keep the queue full
+	b := batcher.New(
+		batcher.WithBatchSize[test.BatchItem](2),
+		batcher.WithBatchInterval[test.BatchItem](10*time.Second),
+		batcher.WithMaxQueueSize[test.BatchItem](4),
+		batcher.WithProcessor(func(_ []test.BatchItem) error {
+			time.Sleep(50 * time.Millisecond) // slow processor
+			return nil
+		}),
+	)
+	defer b.Close()
+
+	// ACT — fill the queue (4 items = queue cap)
+	for i := 0; i < 4; i++ {
+		b.Add(test.BatchItem{Key: fmt.Sprintf("key_%d", i)})
+	}
+
+	// The 5th Add should block because the queue is full.
+	// Use a goroutine with a timeout to verify it blocks.
+	done := make(chan struct{})
+	go func() {
+		b.Add(test.BatchItem{Key: "blocked"})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// If Add returns immediately, the queue didn't block — that's wrong
+		// unless the processor already drained items. Give a small window.
+		// If it returns within 5ms, the queue likely isn't blocking.
+		t.Log("Add returned quickly — processor may have drained the queue, which is acceptable")
+	case <-time.After(20 * time.Millisecond):
+		// Add blocked for 20ms — the queue is applying backpressure. Good.
+	}
+
+	// ASSERT — eventually all items are processed
+	require.NoError(t, b.Join(500*time.Millisecond))
+	require.Equal(t, 0, b.Len())
+}
+
+func TestMaxQueueSizeDefaultIsUnbounded(t *testing.T) {
+	// ARRANGE — no MaxQueueSize set, should be unbounded
+	processed := atomic.NewInt32(0)
+	b := batcher.New(
+		batcher.WithBatchSize[test.BatchItem](100),
+		batcher.WithBatchInterval[test.BatchItem](1*time.Millisecond),
+		batcher.WithProcessor(func(items []test.BatchItem) error {
+			processed.Add(int32(len(items)))
+			return nil
+		}),
+	)
+	defer b.Close()
+
+	// ACT — add many more items than any reasonable queue cap
+	for i := 0; i < 10000; i++ {
+		b.Add(test.BatchItem{Key: fmt.Sprintf("key_%d", i)})
+	}
+
+	// ASSERT — all items processed, no blocking
+	require.NoError(t, b.Join(500*time.Millisecond))
+	require.Equal(t, 0, b.Len())
+	require.EqualValues(t, 10000, processed.Load())
+}
+
+func TestMaxQueueSizeZeroIsIgnored(t *testing.T) {
+	// ARRANGE
+	b := batcher.New(
+		batcher.WithMaxQueueSize[test.BatchItem](0),
+	)
+	defer b.Close()
+
+	// ASSERT — config should remain 0 (unbounded)
+	require.Equal(t, 0, b.Config().MaxQueueSize)
+}
+
 func TestProcessesEntireBatchesIfTimerHasNotExpired(t *testing.T) {
 	// ARRANGE
 	batches := atomic.NewInt32(0)

--- a/pkg/batcher/batcher_test.go
+++ b/pkg/batcher/batcher_test.go
@@ -307,13 +307,17 @@ func TestMaxQueueSizeDefaultIsUnbounded(t *testing.T) {
 }
 
 func TestMaxQueueSizeAddUnblocksOnClose(t *testing.T) {
-	// ARRANGE — processor blocks forever, queue fills up, Add blocks
+	// ARRANGE — processor blocks until cleanup, queue fills up, Add blocks
+	processorDone := make(chan struct{})
+	t.Cleanup(func() { close(processorDone) })
+
 	b := batcher.New(
 		batcher.WithBatchSize[test.BatchItem](2),
 		batcher.WithBatchInterval[test.BatchItem](10*time.Second),
 		batcher.WithMaxQueueSize[test.BatchItem](4),
 		batcher.WithProcessor(func(_ []test.BatchItem) error {
-			select {} // block forever — simulates hung processor
+			<-processorDone
+			return nil
 		}),
 	)
 
@@ -342,7 +346,6 @@ func TestMaxQueueSizeAddUnblocksOnClose(t *testing.T) {
 	// ASSERT — Add must return promptly after Close
 	select {
 	case <-addReturned:
-		// Good — Add unblocked on shutdown
 	case <-time.After(1 * time.Second):
 		t.Fatal("Add still blocked after Close — deadlock")
 	}

--- a/pkg/batcher/batcher_test.go
+++ b/pkg/batcher/batcher_test.go
@@ -351,14 +351,13 @@ func TestMaxQueueSizeAddUnblocksOnClose(t *testing.T) {
 	}
 }
 
-func TestMaxQueueSizeZeroIsIgnored(t *testing.T) {
-	// ARRANGE
+func TestMaxQueueSizeZeroResetsToUnbounded(t *testing.T) {
 	b := batcher.New(
+		batcher.WithMaxQueueSize[test.BatchItem](100),
 		batcher.WithMaxQueueSize[test.BatchItem](0),
 	)
 	defer b.Close()
 
-	// ASSERT — config should remain 0 (unbounded)
 	require.Equal(t, 0, b.Config().MaxQueueSize)
 }
 

--- a/pkg/batcher/options.go
+++ b/pkg/batcher/options.go
@@ -44,9 +44,11 @@ func WithBatchInterval[T any](batchInterval time.Duration) Option[T] {
 // A value of 0 (the default) means the queue is unbounded.
 func WithMaxQueueSize[T any](size int) Option[T] {
 	return func(b *Batcher[T]) {
-		if size > 0 {
-			b.config.MaxQueueSize = size
+		if size < 0 {
+			size = 0
 		}
+
+		b.config.MaxQueueSize = size
 	}
 }
 

--- a/pkg/batcher/options.go
+++ b/pkg/batcher/options.go
@@ -35,6 +35,21 @@ func WithBatchInterval[T any](batchInterval time.Duration) Option[T] {
 	}
 }
 
+// WithMaxQueueSize sets the maximum number of items that can be queued for
+// batching. When the queue is full, Add blocks until space is available. This
+// provides natural backpressure to callers — for example, a Kafka consumer's
+// Handle() will block, preventing the consumer from reading ahead of what the
+// processor can handle.
+//
+// A value of 0 (the default) means the queue is unbounded.
+func WithMaxQueueSize[T any](size int) Option[T] {
+	return func(b *Batcher[T]) {
+		if size > 0 {
+			b.config.MaxQueueSize = size
+		}
+	}
+}
+
 // WithSkipAutoStart skips the automatic start of the batcher.
 func WithSkipAutoStart[T any]() Option[T] {
 	return func(b *Batcher[T]) {


### PR DESCRIPTION
## Summary

Add `WithMaxQueueSize` option that bounds the batcher's internal queue. When the queue is full, `Add()` blocks until space is available, providing natural backpressure to callers.

## Motivation

The batcher currently uses an unbounded input channel (`chann.Cap(-1)`). If the processor is slower than the producer, items accumulate without limit — eventually causing OOM. This is particularly problematic in Kafka consumer pipelines where `Handle()` calls `batcher.Add()` and returns immediately: the consumer reads ahead of what the processor can handle, building up an unbounded in-memory queue.

With `WithMaxQueueSize`, `Add()` blocks when the queue is full. In a Kafka consumer, this means `Handle()` blocks, which stops the consumer from polling — the same natural backpressure that TCP windows and Go buffered channels provide.

## Usage

```go
b := batcher.New(
    batcher.WithBatchSize[T](100),
    batcher.WithBatchInterval[T](100*time.Millisecond),
    batcher.WithMaxQueueSize[T](1000), // ~10 batches of buffer
    batcher.WithProcessor(handler.processBatch),
)
```

Default behavior (`MaxQueueSize = 0`) remains unbounded for backward compatibility.

## Test plan

- [x] `go test ./...` passes
- [x] `go test -race ./...` passes
- [x] New tests: queue blocks when full, default is unbounded, zero is ignored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added configuration option to set a maximum queue size for the batcher. When the queue reaches capacity, new items will block until space becomes available, enabling backpressure and memory control.
- Enhanced shutdown behavior to gracefully close the batcher, releasing any pending additions during closure.

## Tests
- Added comprehensive test coverage for queue size limits, blocking behavior, and shutdown scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->