### PR TITLE
chore: sync main with released v0.2.1 code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ build
 
 dist/
 dist
+.mcp.json
+.claude-flow
+.swarm

--- a/pkg/batcher/batcher.go
+++ b/pkg/batcher/batcher.go
@@ -87,28 +87,46 @@ func (b *Batcher[T]) Len() int {
 }
 
 func (b *Batcher[T]) Join(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+
 	for {
-		select {
-		case <-time.After(timeout):
-			return ErrTimeout
-		default:
-			if b.Len() == 0 {
-				return nil
-			}
-			time.Sleep(1 * time.Millisecond)
+		if b.Len() == 0 {
+			return nil
 		}
+
+		if time.Now().After(deadline) {
+			return ErrTimeout
+		}
+
+		time.Sleep(1 * time.Millisecond)
 	}
 }
 
 func (b *Batcher[T]) startProcessing() {
+	// Close channels in the correct order to prevent goroutine leaks:
+	// 1. First close the input channel to stop the rill pipeline from producing more batches
+	// 2. Then drain the output channel to allow rill goroutines to exit cleanly
+	// 3. Finally close the errors channel
 	defer b.errorsChan.Close()
+	defer func() {
+		// Drain any remaining batches from the rill pipeline to ensure
+		// all rill goroutines can exit cleanly. This prevents goroutine leaks.
+		for range b.batchesChan {
+			// Just drain, don't process during shutdown
+		}
+	}()
 	defer b.batchInputChan.Close()
 
 	for {
 		select {
 		case <-b.doneChan:
 			return
-		case batch := <-b.batchesChan:
+		case batch, ok := <-b.batchesChan:
+			if !ok {
+				// Channel closed, exit gracefully
+				return
+			}
+
 			if batch.Error != nil {
 				b.errorsChan.In() <- batch.Error
 
@@ -132,11 +150,29 @@ func (b *Batcher[T]) Close() error {
 	var clErr error
 
 	b.closeOnce.Do(func() {
+		// Calculate timeout based on pending items, with a maximum of 10 seconds
 		timeout := time.Duration(2*2*math.Ceil(float64(b.Len())/float64(b.config.BatchSize))) *
 			b.config.BatchInterval
+
+		// Cap the timeout at 10 seconds to prevent indefinite blocking
+		maxTimeout := 10 * time.Second
+		if timeout > maxTimeout {
+			timeout = maxTimeout
+		}
+
+		// Ensure a minimum timeout of 100ms
+		if timeout < 100*time.Millisecond {
+			timeout = 100 * time.Millisecond
+		}
+
 		clErr = b.Join(timeout)
 
+		// Signal shutdown to the processing goroutine
 		close(b.doneChan)
+
+		// Give the goroutine a moment to exit cleanly
+		// This allows the deferred cleanup to run
+		time.Sleep(50 * time.Millisecond)
 
 		b.isClosed = true
 	})

--- a/pkg/batcher/goroutine_leak_test.go
+++ b/pkg/batcher/goroutine_leak_test.go
@@ -1,0 +1,450 @@
+package batcher_test
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/NSXBet/batcher/pkg/batcher"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+// TestBatcher_GoroutineCleanupOnStop is the main regression test for goroutine leaks.
+// It reproduces the issue where goroutines remain blocked after Close() is called.
+func TestBatcher_GoroutineCleanupOnStop(t *testing.T) {
+	processCount := atomic.NewInt32(0)
+
+	processor := func(items []string) error {
+		count := processCount.Add(1)
+		time.Sleep(100 * time.Millisecond) // Simulate processing
+
+		// Simulate failure after processing some batches
+		if count > 2 {
+			return errors.New("simulated processing failure")
+		}
+		return nil
+	}
+
+	b := batcher.New(
+		batcher.WithBatchSize[string](5),
+		batcher.WithBatchInterval[string](100*time.Millisecond),
+		batcher.WithProcessor(processor),
+	)
+
+	// Add messages actively while batcher is running
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			b.Add(fmt.Sprintf("msg-%d", i))
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	// Let some batches process
+	time.Sleep(500 * time.Millisecond)
+
+	// Stop the batcher (simulating consumer crash/shutdown)
+	startGoroutines := runtime.NumGoroutine()
+	t.Logf("Goroutines before Close(): %d", startGoroutines)
+
+	err := b.Close()
+	if err != nil {
+		t.Logf("Batcher close returned error: %v", err)
+	}
+
+	wg.Wait()
+
+	// VERIFY: All goroutines should exit within reasonable time
+	timeout := time.After(5 * time.Second)
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeout:
+			currentGoroutines := runtime.NumGoroutine()
+			t.Fatalf("Goroutine leak detected: started with %d, still have %d after 5 seconds (leaked %d goroutines)",
+				startGoroutines, currentGoroutines, currentGoroutines-startGoroutines)
+		case <-ticker.C:
+			currentGoroutines := runtime.NumGoroutine()
+			t.Logf("Current goroutines: %d", currentGoroutines)
+			// Allow small variance (±2 goroutines for test runtime)
+			if currentGoroutines <= startGoroutines+2 {
+				t.Logf("✅ All goroutines cleaned up successfully (start: %d, current: %d)", startGoroutines, currentGoroutines)
+				return
+			}
+		}
+	}
+}
+
+// TestBatcher_StopWithPendingMessages tests that pending messages don't block goroutine cleanup.
+func TestBatcher_StopWithPendingMessages(t *testing.T) {
+	processedBatches := atomic.NewInt32(0)
+
+	processor := func(items []string) error {
+		processedBatches.Add(1)
+		time.Sleep(50 * time.Millisecond)
+		return nil
+	}
+
+	b := batcher.New(
+		batcher.WithBatchSize[string](10),
+		batcher.WithBatchInterval[string](1*time.Second), // Long interval
+		batcher.WithProcessor(processor),
+	)
+
+	// Add only 5 items (less than batch size), so they won't trigger batch processing
+	for i := 0; i < 5; i++ {
+		b.Add(fmt.Sprintf("msg-%d", i))
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	startGoroutines := runtime.NumGoroutine()
+	t.Logf("Goroutines before Close(): %d", startGoroutines)
+
+	// Close should not block indefinitely even with pending messages
+	closeStart := time.Now()
+	err := b.Close()
+	closeDuration := time.Since(closeStart)
+
+	t.Logf("Close() took %v, returned error: %v", closeDuration, err)
+
+	// Verify goroutine cleanup
+	timeout := time.After(5 * time.Second)
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeout:
+			currentGoroutines := runtime.NumGoroutine()
+			t.Fatalf("Goroutine leak detected: started with %d, still have %d after 5 seconds",
+				startGoroutines, currentGoroutines)
+		case <-ticker.C:
+			currentGoroutines := runtime.NumGoroutine()
+			if currentGoroutines <= startGoroutines+2 {
+				t.Logf("✅ All goroutines cleaned up successfully")
+				return
+			}
+		}
+	}
+}
+
+// TestBatcher_StopWhileProcessing tests cleanup when the processor is actively working.
+func TestBatcher_StopWhileProcessing(t *testing.T) {
+	processing := atomic.NewBool(false)
+	processingDone := make(chan struct{})
+
+	processor := func(items []string) error {
+		processing.Store(true)
+		time.Sleep(2 * time.Second) // Long processing time
+		processing.Store(false)
+		close(processingDone)
+		return nil
+	}
+
+	b := batcher.New(
+		batcher.WithBatchSize[string](5),
+		batcher.WithBatchInterval[string](10*time.Millisecond),
+		batcher.WithProcessor(processor),
+	)
+
+	// Add enough items to trigger processing
+	for i := 0; i < 5; i++ {
+		b.Add(fmt.Sprintf("msg-%d", i))
+	}
+
+	// Wait for processing to start
+	time.Sleep(100 * time.Millisecond)
+	require.True(t, processing.Load(), "Processing should have started")
+
+	startGoroutines := runtime.NumGoroutine()
+	t.Logf("Goroutines before Close(): %d", startGoroutines)
+
+	// Close while processing is ongoing
+	closeStart := time.Now()
+	err := b.Close()
+	closeDuration := time.Since(closeStart)
+
+	t.Logf("Close() took %v, returned error: %v", closeDuration, err)
+
+	// Wait for processing to complete
+	select {
+	case <-processingDone:
+		t.Logf("Processing completed")
+	case <-time.After(3 * time.Second):
+		t.Logf("Processing did not complete within timeout")
+	}
+
+	// Verify goroutine cleanup
+	timeout := time.After(5 * time.Second)
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeout:
+			currentGoroutines := runtime.NumGoroutine()
+			t.Fatalf("Goroutine leak detected: started with %d, still have %d after 5 seconds",
+				startGoroutines, currentGoroutines)
+		case <-ticker.C:
+			currentGoroutines := runtime.NumGoroutine()
+			if currentGoroutines <= startGoroutines+2 {
+				t.Logf("✅ All goroutines cleaned up successfully")
+				return
+			}
+		}
+	}
+}
+
+// TestBatcher_StopWithFailingProcessor tests cleanup when the processor consistently fails.
+func TestBatcher_StopWithFailingProcessor(t *testing.T) {
+	processCount := atomic.NewInt32(0)
+
+	processor := func(items []string) error {
+		processCount.Add(1)
+		time.Sleep(50 * time.Millisecond)
+		return errors.New("processor always fails")
+	}
+
+	b := batcher.New(
+		batcher.WithBatchSize[string](5),
+		batcher.WithBatchInterval[string](50*time.Millisecond),
+		batcher.WithProcessor(processor),
+	)
+
+	// Add many items that will all fail processing
+	for i := 0; i < 50; i++ {
+		b.Add(fmt.Sprintf("msg-%d", i))
+	}
+
+	// Let some failures occur
+	time.Sleep(200 * time.Millisecond)
+
+	startGoroutines := runtime.NumGoroutine()
+	t.Logf("Goroutines before Close(): %d, processed %d batches", startGoroutines, processCount.Load())
+
+	err := b.Close()
+	t.Logf("Close() returned error: %v", err)
+
+	// Verify goroutine cleanup
+	timeout := time.After(5 * time.Second)
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeout:
+			currentGoroutines := runtime.NumGoroutine()
+			t.Fatalf("Goroutine leak detected: started with %d, still have %d after 5 seconds",
+				startGoroutines, currentGoroutines)
+		case <-ticker.C:
+			currentGoroutines := runtime.NumGoroutine()
+			if currentGoroutines <= startGoroutines+2 {
+				t.Logf("✅ All goroutines cleaned up successfully")
+				return
+			}
+		}
+	}
+}
+
+// TestBatcher_RapidStartStopCycles tests multiple rapid create/close cycles for leaks.
+func TestBatcher_RapidStartStopCycles(t *testing.T) {
+	initialGoroutines := runtime.NumGoroutine()
+	t.Logf("Initial goroutines: %d", initialGoroutines)
+
+	processor := func(items []string) error {
+		time.Sleep(10 * time.Millisecond)
+		return nil
+	}
+
+	// Perform multiple rapid start/stop cycles
+	for cycle := 0; cycle < 10; cycle++ {
+		b := batcher.New(
+			batcher.WithBatchSize[string](5),
+			batcher.WithBatchInterval[string](50*time.Millisecond),
+			batcher.WithProcessor(processor),
+		)
+
+		// Add some items
+		for i := 0; i < 10; i++ {
+			b.Add(fmt.Sprintf("cycle-%d-msg-%d", cycle, i))
+		}
+
+		time.Sleep(50 * time.Millisecond)
+
+		err := b.Close()
+		if err != nil {
+			t.Logf("Cycle %d: Close() returned error: %v", cycle, err)
+		}
+
+		// Give a bit of time for cleanup
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Verify no goroutine accumulation after all cycles
+	timeout := time.After(5 * time.Second)
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeout:
+			currentGoroutines := runtime.NumGoroutine()
+			// Allow some growth but not excessive (10 cycles shouldn't leak 50+ goroutines)
+			if currentGoroutines > initialGoroutines+10 {
+				t.Fatalf("Goroutine accumulation detected: started with %d, now have %d after 10 cycles (leaked %d)",
+					initialGoroutines, currentGoroutines, currentGoroutines-initialGoroutines)
+			}
+			t.Logf("✅ Acceptable goroutine count after cycles: %d (started with %d)", currentGoroutines, initialGoroutines)
+			return
+		case <-ticker.C:
+			currentGoroutines := runtime.NumGoroutine()
+			t.Logf("Current goroutines: %d", currentGoroutines)
+			// If we're back to initial (±5 for test overhead), we're good
+			if currentGoroutines <= initialGoroutines+5 {
+				t.Logf("✅ All goroutines cleaned up successfully after cycles: %d (started with %d)", currentGoroutines, initialGoroutines)
+				return
+			}
+		}
+	}
+}
+
+// TestBatcher_CloseTimeoutBehavior tests that Close() doesn't block forever.
+func TestBatcher_CloseTimeoutBehavior(t *testing.T) {
+	// Processor that never returns
+	processor := func(items []string) error {
+		time.Sleep(10 * time.Minute) // Intentionally long
+		return nil
+	}
+
+	b := batcher.New(
+		batcher.WithBatchSize[string](5),
+		batcher.WithBatchInterval[string](10*time.Millisecond),
+		batcher.WithProcessor(processor),
+	)
+
+	// Add items to trigger processing
+	for i := 0; i < 5; i++ {
+		b.Add(fmt.Sprintf("msg-%d", i))
+	}
+
+	// Wait for processing to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Close() should return within a reasonable time, even though processor is blocked
+	closeStart := time.Now()
+	closeDone := make(chan error, 1)
+
+	go func() {
+		closeDone <- b.Close()
+	}()
+
+	select {
+	case err := <-closeDone:
+		closeDuration := time.Since(closeStart)
+		t.Logf("Close() completed in %v with error: %v", closeDuration, err)
+
+		// Close should complete within a reasonable timeout (not 10 minutes)
+		if closeDuration > 10*time.Second {
+			t.Errorf("Close() took too long: %v", closeDuration)
+		}
+
+	case <-time.After(15 * time.Second):
+		t.Fatal("Close() blocked for more than 15 seconds - this is unacceptable")
+	}
+}
+
+// TestBatcher_MultipleCloseCallsNoDeadlock tests that multiple Close() calls don't deadlock.
+func TestBatcher_MultipleCloseCallsNoDeadlock(t *testing.T) {
+	processor := func(items []string) error {
+		time.Sleep(10 * time.Millisecond)
+		return nil
+	}
+
+	b := batcher.New(
+		batcher.WithBatchSize[string](5),
+		batcher.WithBatchInterval[string](50*time.Millisecond),
+		batcher.WithProcessor(processor),
+	)
+
+	for i := 0; i < 10; i++ {
+		b.Add(fmt.Sprintf("msg-%d", i))
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Call Close() concurrently from multiple goroutines
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			err := b.Close()
+			t.Logf("Close() call %d returned: %v", id, err)
+		}(i)
+	}
+
+	// Wait for all Close() calls to complete
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Logf("✅ All Close() calls completed without deadlock")
+	case <-time.After(10 * time.Second):
+		t.Fatal("Multiple Close() calls resulted in deadlock")
+	}
+}
+
+// TestBatcher_NoLeakWithEmptyBatcher tests that even an empty batcher cleans up properly.
+func TestBatcher_NoLeakWithEmptyBatcher(t *testing.T) {
+	processor := func(items []string) error {
+		return nil
+	}
+
+	startGoroutines := runtime.NumGoroutine()
+	t.Logf("Goroutines before batcher creation: %d", startGoroutines)
+
+	b := batcher.New(
+		batcher.WithBatchSize[string](5),
+		batcher.WithBatchInterval[string](100*time.Millisecond),
+		batcher.WithProcessor(processor),
+	)
+
+	// Don't add any items, just close immediately
+	time.Sleep(50 * time.Millisecond)
+
+	err := b.Close()
+	t.Logf("Close() returned: %v", err)
+
+	// Verify goroutine cleanup
+	timeout := time.After(5 * time.Second)
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeout:
+			currentGoroutines := runtime.NumGoroutine()
+			t.Fatalf("Goroutine leak detected: started with %d, still have %d after 5 seconds",
+				startGoroutines, currentGoroutines)
+		case <-ticker.C:
+			currentGoroutines := runtime.NumGoroutine()
+			if currentGoroutines <= startGoroutines+2 {
+				t.Logf("✅ All goroutines cleaned up successfully (empty batcher)")
+				return
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- merge the existing `nsx001164/fix-bug` branch so `main` matches the `v0.2.1` code already released to production
- make `main` the correct base for follow-on work
- preserve the existing release diff as-is, including the shutdown fix and its regression coverage

## Test plan
- [ ] GitHub Actions passes on this PR
- [ ] Review the small `.gitignore` additions included on the branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batcher shutdown to prevent goroutine leaks and ensure graceful termination under varied runtime and timeout conditions.

* **Tests**
  * Added a comprehensive regression suite validating cleanup, bounded Close() timing, and robust behavior across multiple shutdown scenarios.

* **Chores**
  * Updated repository ignore settings to exclude three new local/config files from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->