### PR TITLE
feat: add bounded queue mode to batcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@
 
 The dead-simple batching solution for golang applications.
 
+With batcher you can easily batch operations and run them asynchronously in batches.
+By default, batcher uses an unbounded internal queue so fire-and-forget producers
+can enqueue quickly. If you configure `WithMaxQueueSize`, batcher switches to a
+bounded queue that adds natural backpressure by blocking producers when the queue
+is full.
+
+This makes the package useful for two different producer styles:
+
+- fire-and-forget request paths that prefer the default unbounded queue and `Add`
+- pull-based consumers such as Kafka loops that benefit from bounded queues and
+  `Enqueue(ctx, item)`
+
 With batcher you can easily batch operations and run them asynchronously in batches:
 
 ```go
@@ -147,7 +159,7 @@ batcher := batcher.New[*BatchItem](
 
 ### Adding items to the batcher
 
-To add items to the batcher you can use the `Add` function:
+Use `Add` when you want the simplest producer API:
 
 ```go
 for i := 0; i < 1000; i++ {
@@ -157,6 +169,38 @@ for i := 0; i < 1000; i++ {
     })
 }
 ```
+
+`Add` is the convenience API:
+
+- in unbounded mode, it remains effectively immediate unless shutdown has started
+- in bounded mode, it blocks while the queue is full
+- once shutdown has started, it silently drops the item
+
+Use `Enqueue(ctx, item)` when the caller needs precise control over admission:
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+defer cancel()
+
+err := batcher.Enqueue(ctx, &BatchItem{
+    ID:   42,
+    Name: "important-item",
+})
+if err != nil {
+    // err can be context.Canceled, context.DeadlineExceeded, or batcher.ErrClosing
+}
+```
+
+`Enqueue` is the explicit API:
+
+- in unbounded mode, it usually returns immediately unless shutdown has started
+- in bounded mode, it waits until there is queue capacity
+- if the caller's context is canceled while waiting, it returns the context error
+- if shutdown begins while waiting, it returns `batcher.ErrClosing`
+
+Calls that race exactly with `Close()` may still be accepted if the send wins
+before shutdown becomes visible. Accepted items are still drained by `Join()` or
+`Close()`.
 
 ### Waiting for all batches to process
 
@@ -171,7 +215,7 @@ if err := batcher.Join(timeout); err != nil {
 
 ### Stopping the batcher
 
-To stop the batcher you can use the `StopProcessing` function:
+To stop the batcher you can use the `Close` function:
 
 ```go
 defer batcher.Close()
@@ -199,10 +243,82 @@ You can get how many items are in the batcher by using the `Len` function:
 fmt.Printf("batcher has %d items\n", batcher.Len())
 ```
 
+### Choosing unbounded or bounded mode
+
+Batcher defaults to an unbounded internal queue:
+
+```go
+batcher := batcher.New[*BatchItem](
+    batcher.WithBatchSize[*BatchItem](100),
+    batcher.WithBatchInterval[*BatchItem](time.Second),
+)
+```
+
+This mode is a good default for request-scoped code that wants a cheap enqueue
+path and is willing to absorb bursts in memory.
+
+If you want natural backpressure, configure a bounded queue:
+
+```go
+batcher := batcher.New[*BatchItem](
+    batcher.WithBatchSize[*BatchItem](100),
+    batcher.WithBatchInterval[*BatchItem](time.Second),
+    batcher.WithMaxQueueSize[*BatchItem](1_000),
+)
+```
+
+In bounded mode:
+
+- producers block when the queue is full
+- waiting producers unblock as soon as the consumer drains capacity
+- `Add` silently drops once shutdown has started
+- `Enqueue` returns `batcher.ErrClosing` once shutdown has started
+
+The queue bound is about accepted-but-not-yet-drained items. It is most useful
+for consumer loops where slowing the producer is better than allowing memory
+growth during downstream slowness.
+
+### Kafka-style bounded backpressure
+
+Bounded queues pair well with pull-based consumers because backpressure on
+enqueue naturally slows how fast records move from the consumer loop into the
+batcher:
+
+```go
+for {
+    fetches := client.PollFetches(ctx)
+    if ctx.Err() != nil {
+        break
+    }
+
+    fetches.EachRecord(func(record *kgo.Record) {
+        item := &BatchItem{
+            ID:   int(record.Offset),
+            Name: string(record.Key),
+        }
+
+        if err := batcher.Enqueue(ctx, item); err != nil {
+            switch {
+            case errors.Is(err, context.Canceled):
+                return
+            case errors.Is(err, batcher.ErrClosing):
+                return
+            default:
+                log.Printf("enqueue failed: %v", err)
+            }
+        }
+    })
+}
+```
+
+This pattern is safer than `Add` for shutdown-aware consumers because the caller
+can observe cancellation, deadlines, and close-time rejection explicitly.
+
 ## Available Options to configure batcher
 
 - `WithBatchSize[*BatchItem](size int)`: sets the batch size.
 - `WithBatchInterval[*BatchItem](interval time.Duration)`: sets the batch interval.
+- `WithMaxQueueSize[*BatchItem](size int)`: sets the maximum queue size. Values less than or equal to zero keep the queue unbounded.
 - `WithProcessor(func(items []*BatchItem) error)`: sets the processor function.
 
 ## FX Integration
@@ -213,7 +329,6 @@ The batcher can be easily integrated with [uber-go/fx](https://github.com/uber-g
 package main
 
 import (
-    "fmt"
     "time"
 
     "go.uber.org/fx"
@@ -278,6 +393,7 @@ func main() {
             },
             2,                    // batch size
             time.Millisecond*100, // batch interval
+            0,                    // max queue size; use > 0 to enable bounded mode
         ),
         // Provide the request handler
         fx.Provide(NewRequestHandler),
@@ -301,6 +417,8 @@ This allows you to:
 - Let FX handle the dependency injection and lifecycle management
 
 The batcher will be automatically started when the FX app starts and stopped when the app stops.
+Pass a positive `maxQueueSize` to `ProvideBatcherInFX` when the Fx-managed
+application should run in bounded mode.
 
 ## Tests
 
@@ -316,26 +434,28 @@ For the most up-to-date benchmarks in this repository, you can access [this
 page](https://nsxbet.github.io/batcher/dev/bench/). These results are run every time someone merges a PR into the main
 branch.
 
-Our benchmarks are divided by batch size and should look like this (actual results depend on your machine):
+The benchmark suite is scenario-driven and compares unbounded and bounded queue
+modes side by side. It includes enqueue-only throughput, end-to-end batch
+throughput, concurrent producer contention, single-item latency, and
+shutdown/drain scenarios.
+
+The output should look roughly like this (actual results depend on your machine):
 
 ```bash
-Running benchmarks...
-2024-06-07T00:21:10.619-0300    INFO    test/helpers.go:30        processing items {"count": 1000}
 goos: linux
 goarch: amd64
 pkg: github.com/NSXBet/batcher/pkg/batcher
 cpu: Intel(R) Core(TM) i9-14900KF
-BenchmarkBatcherBatchSize10-24           4588717         255.4 ns/op
-BenchmarkBatcherBatchSize100-24          5017683         254.8 ns/op
-BenchmarkBatcherBatchSize1_000-24        4721426         235.4 ns/op
-BenchmarkBatcherBatchSize10_000-24       4603827         245.5 ns/op
-BenchmarkBatcherBatchSize100_000-24      4848703         244.8 ns/op
+BenchmarkBatcherEnqueueOnly/unbounded/steady_high_volume_flushes_by_size_batch_100-24
+BenchmarkBatcherEnqueueOnly/bounded_cap_100/steady_high_volume_flushes_by_size_batch_100-24
+BenchmarkBatcherConcurrentProducers/unbounded/many_producers_flush_by_size_batch_100-24
+BenchmarkBatcherConcurrentProducers/bounded_cap_100/many_producers_flush_by_size_batch_100-24
 PASS
 ok      github.com/NSXBet/batcher/pkg/batcher     26.988s
 ```
 
-These benchmarks take into account the time it takes to add items to the batcher, not the time to process the batches as
-that will vary depending on the processor function you pass to the batcher.
+The point of these benchmarks is to compare bounded and unbounded tradeoffs in
+the same workload families rather than to report one global "fastest" number.
 
 ## License
 

--- a/pkg/batcher/batcher.go
+++ b/pkg/batcher/batcher.go
@@ -1,6 +1,8 @@
 package batcher
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -10,6 +12,7 @@ import (
 )
 
 var ErrTimeout = fmt.Errorf("timeout waiting for batches to complete")
+var ErrClosing = errors.New("batcher is closing")
 
 type Processor[T any] func([]T) error
 
@@ -32,6 +35,7 @@ type Batcher[T any] struct {
 	isClosed       bool
 	closeOnce      sync.Once
 	itemCount      *AtomicCounter
+	stopAccepting  chan struct{}
 	doneChan       chan struct{}
 	errorsChan     *chann.Chann[error]
 	batchInputChan *chann.Chann[T]
@@ -49,6 +53,7 @@ func New[T any](options ...Option[T]) *Batcher[T] {
 		},
 
 		itemCount:      NewAtomicCounter(),
+		stopAccepting:  make(chan struct{}),
 		doneChan:       make(chan struct{}),
 		batchInputChan: chann.New[T](chann.Cap(-1)),
 	}
@@ -75,8 +80,35 @@ func (b *Batcher[T]) Config() *Config[T] {
 }
 
 func (b *Batcher[T]) Add(item T) {
-	b.batchInputChan.In() <- item
-	b.itemCount.Add(1)
+	_ = b.Enqueue(context.Background(), item)
+}
+
+func (b *Batcher[T]) Enqueue(ctx context.Context, item T) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	select {
+	case <-b.stopAccepting:
+		return ErrClosing
+	default:
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-b.stopAccepting:
+		return ErrClosing
+	case b.batchInputChan.In() <- item:
+		b.itemCount.Add(1)
+		return nil
+	}
 }
 
 func (b *Batcher[T]) Len() int {
@@ -178,6 +210,8 @@ func (b *Batcher[T]) Close() error {
 	var clErr error
 
 	b.closeOnce.Do(func() {
+		close(b.stopAccepting)
+
 		// Calculate timeout based on pending items, with a maximum of 10 seconds
 		timeout := time.Duration(2*2*math.Ceil(float64(b.Len())/float64(b.config.BatchSize))) *
 			b.config.BatchInterval

--- a/pkg/batcher/batcher.go
+++ b/pkg/batcher/batcher.go
@@ -38,6 +38,7 @@ type Batcher[T any] struct {
 	stopAccepting  chan struct{}
 	doneChan       chan struct{}
 	errorsChan     *chann.Chann[error]
+	boundedInputCh chan T
 	batchInputChan *chann.Chann[T]
 }
 
@@ -52,14 +53,19 @@ func New[T any](options ...Option[T]) *Batcher[T] {
 			ProcessorFunc: NoOpProcessor[T],
 		},
 
-		itemCount:      NewAtomicCounter(),
-		stopAccepting:  make(chan struct{}),
-		doneChan:       make(chan struct{}),
-		batchInputChan: chann.New[T](chann.Cap(-1)),
+		itemCount:     NewAtomicCounter(),
+		stopAccepting: make(chan struct{}),
+		doneChan:      make(chan struct{}),
 	}
 
 	for _, option := range options {
 		option(b)
+	}
+
+	if b.config.MaxQueueSize > 0 {
+		b.boundedInputCh = make(chan T, b.config.MaxQueueSize)
+	} else {
+		b.batchInputChan = chann.New[T](chann.Cap(-1))
 	}
 
 	b.errorsChan = chann.New[error](chann.Cap(-1))
@@ -84,6 +90,8 @@ func (b *Batcher[T]) Add(item T) {
 }
 
 func (b *Batcher[T]) Enqueue(ctx context.Context, item T) error {
+	inputCh := b.inputSendCh()
+
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -105,9 +113,31 @@ func (b *Batcher[T]) Enqueue(ctx context.Context, item T) error {
 		return ctx.Err()
 	case <-b.stopAccepting:
 		return ErrClosing
-	case b.batchInputChan.In() <- item:
+	case inputCh <- item:
 		b.itemCount.Add(1)
 		return nil
+	}
+}
+
+func (b *Batcher[T]) inputSendCh() chan<- T {
+	if b.boundedInputCh != nil {
+		return b.boundedInputCh
+	}
+
+	return b.batchInputChan.In()
+}
+
+func (b *Batcher[T]) inputRecvCh() <-chan T {
+	if b.boundedInputCh != nil {
+		return b.boundedInputCh
+	}
+
+	return b.batchInputChan.Out()
+}
+
+func (b *Batcher[T]) closeInput() {
+	if b.batchInputChan != nil {
+		b.batchInputChan.Close()
 	}
 }
 
@@ -133,7 +163,9 @@ func (b *Batcher[T]) Join(timeout time.Duration) error {
 
 func (b *Batcher[T]) startProcessing() {
 	defer b.errorsChan.Close()
-	defer b.batchInputChan.Close()
+	defer b.closeInput()
+
+	inputCh := b.inputRecvCh()
 
 	var (
 		batch  []T
@@ -176,7 +208,7 @@ func (b *Batcher[T]) startProcessing() {
 		select {
 		case <-b.doneChan:
 			return
-		case item, ok := <-b.batchInputChan.Out():
+		case item, ok := <-inputCh:
 			if !ok {
 				return
 			}

--- a/pkg/batcher/batcher.go
+++ b/pkg/batcher/batcher.go
@@ -12,7 +12,10 @@ import (
 	"golang.design/x/chann"
 )
 
+// ErrTimeout indicates that Join or Close timed out before accepted work drained.
 var ErrTimeout = fmt.Errorf("timeout waiting for batches to complete")
+
+// ErrClosing indicates that the batcher stopped accepting new items.
 var ErrClosing = errors.New("batcher is closing")
 
 type Processor[T any] func([]T) error
@@ -25,6 +28,7 @@ type Config[T any] struct {
 	SkipAutoStart bool
 	BatchSize     int
 	BatchInterval time.Duration
+	// MaxQueueSize keeps the queue unbounded when it is less than or equal to zero.
 	MaxQueueSize  int
 	Concurrency   int
 	ProcessorFunc Processor[T]
@@ -103,6 +107,9 @@ func (b *Batcher[T]) Add(item T) {
 	_ = b.Enqueue(context.Background(), item)
 }
 
+// Enqueue adds an item to the batcher, waiting for queue capacity when needed.
+// It returns a context error when the caller stops waiting, or ErrClosing once
+// shutdown has started.
 func (b *Batcher[T]) Enqueue(ctx context.Context, item T) error {
 	inputCh := b.inputSendCh()
 

--- a/pkg/batcher/batcher.go
+++ b/pkg/batcher/batcher.go
@@ -21,6 +21,7 @@ type Config[T any] struct {
 	SkipAutoStart bool
 	BatchSize     int
 	BatchInterval time.Duration
+	MaxQueueSize  int
 	Concurrency   int
 	ProcessorFunc Processor[T]
 }
@@ -42,6 +43,7 @@ func New[T any](options ...Option[T]) *Batcher[T] {
 		config: &Config[T]{
 			BatchSize:     DefaultBatchSize,
 			BatchInterval: DefaultBatchInterval,
+			MaxQueueSize:  0,
 			Concurrency:   DefaultConcurrency,
 			ProcessorFunc: NoOpProcessor[T],
 		},

--- a/pkg/batcher/batcher.go
+++ b/pkg/batcher/batcher.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.design/x/chann"
@@ -33,10 +34,13 @@ type Batcher[T any] struct {
 	config *Config[T]
 
 	isClosed       bool
+	started        atomic.Bool
+	startOnce      sync.Once
 	closeOnce      sync.Once
 	itemCount      *AtomicCounter
 	stopAccepting  chan struct{}
 	doneChan       chan struct{}
+	processingDone chan struct{}
 	errorsChan     *chann.Chann[error]
 	boundedInputCh chan T
 	batchInputChan *chann.Chann[T]
@@ -53,9 +57,10 @@ func New[T any](options ...Option[T]) *Batcher[T] {
 			ProcessorFunc: NoOpProcessor[T],
 		},
 
-		itemCount:     NewAtomicCounter(),
-		stopAccepting: make(chan struct{}),
-		doneChan:      make(chan struct{}),
+		itemCount:      NewAtomicCounter(),
+		stopAccepting:  make(chan struct{}),
+		doneChan:       make(chan struct{}),
+		processingDone: make(chan struct{}),
 	}
 
 	for _, option := range options {
@@ -78,7 +83,16 @@ func New[T any](options ...Option[T]) *Batcher[T] {
 }
 
 func (b *Batcher[T]) Start() {
-	go b.startProcessing()
+	select {
+	case <-b.stopAccepting:
+		return
+	default:
+	}
+
+	b.startOnce.Do(func() {
+		b.started.Store(true)
+		go b.startProcessing()
+	})
 }
 
 func (b *Batcher[T]) Config() *Config[T] {
@@ -162,8 +176,8 @@ func (b *Batcher[T]) Join(timeout time.Duration) error {
 }
 
 func (b *Batcher[T]) startProcessing() {
+	defer close(b.processingDone)
 	defer b.errorsChan.Close()
-	defer b.closeInput()
 
 	inputCh := b.inputRecvCh()
 
@@ -264,9 +278,19 @@ func (b *Batcher[T]) Close() error {
 		// Signal shutdown to the processing goroutine
 		close(b.doneChan)
 
-		// Give the goroutine a moment to exit cleanly
-		// This allows the deferred cleanup to run
-		time.Sleep(50 * time.Millisecond)
+		if b.started.Load() {
+			b.closeInput()
+
+			// Don't block forever if the processor is stuck in user code.
+			select {
+			case <-b.processingDone:
+			case <-time.After(50 * time.Millisecond):
+			}
+		} else {
+			b.closeInput()
+			b.errorsChan.Close()
+			close(b.processingDone)
+		}
 
 		b.isClosed = true
 	})

--- a/pkg/batcher/batcher_behavior_test.go
+++ b/pkg/batcher/batcher_behavior_test.go
@@ -143,6 +143,80 @@ func TestBatchIntervalStartsWhenFirstItemArrives(t *testing.T) {
 	require.NoError(t, b.Join(500*time.Millisecond))
 }
 
+func TestBoundedQueueBlocksUntilConsumerDrainsCapacity(t *testing.T) {
+	processedCh := make(chan []test.BatchItem, 1)
+
+	b := batcher.New(
+		batcher.WithSkipAutoStart[test.BatchItem](),
+		batcher.WithBatchSize[test.BatchItem](10),
+		batcher.WithBatchInterval[test.BatchItem](20*time.Millisecond),
+		batcher.WithMaxQueueSize[test.BatchItem](2),
+		batcher.WithProcessor(func(items []test.BatchItem) error {
+			processedCh <- append([]test.BatchItem(nil), items...)
+			return nil
+		}),
+	)
+	defer b.Close()
+
+	require.NoError(t, b.Enqueue(context.Background(), test.BatchItem{Key: "first"}))
+	require.NoError(t, b.Enqueue(context.Background(), test.BatchItem{Key: "second"}))
+
+	blockedDone := make(chan error, 1)
+	go func() {
+		blockedDone <- b.Enqueue(context.Background(), test.BatchItem{Key: "third"})
+	}()
+
+	select {
+	case err := <-blockedDone:
+		t.Fatalf("enqueue should have blocked, returned %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	require.Equal(t, 2, b.Len(), "only accepted items should count toward Len")
+
+	b.Start()
+
+	select {
+	case err := <-blockedDone:
+		require.NoError(t, err)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for blocked enqueue to unblock")
+	}
+
+	select {
+	case batch := <-processedCh:
+		require.Equal(t, []test.BatchItem{
+			{Key: "first"},
+			{Key: "second"},
+			{Key: "third"},
+		}, batch)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for bounded queue flush")
+	}
+
+	require.NoError(t, b.Join(500*time.Millisecond))
+}
+
+func TestEnqueueReturnsDeadlineExceededWhenBoundedQueueIsFull(t *testing.T) {
+	b := batcher.New(
+		batcher.WithSkipAutoStart[test.BatchItem](),
+		batcher.WithBatchSize[test.BatchItem](10),
+		batcher.WithBatchInterval[test.BatchItem](time.Second),
+		batcher.WithMaxQueueSize[test.BatchItem](1),
+	)
+	defer b.Close()
+
+	require.NoError(t, b.Enqueue(context.Background(), test.BatchItem{Key: "first"}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	err := b.Enqueue(ctx, test.BatchItem{Key: "second"})
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Equal(t, 1, b.Len())
+}
+
 func TestDoesNotEmitEmptyBatchesWhileIdle(t *testing.T) {
 	callCh := make(chan int, 2)
 
@@ -223,6 +297,67 @@ func TestPreservesOrderingAcrossFullAndPartialBatches(t *testing.T) {
 
 	require.Equal(t, []int{3, 3, 2}, batchSizes)
 	require.Equal(t, expectedKeys, keys)
+}
+
+func TestBoundedQueuePreservesOrderingAcrossBlockedEnqueueAndMultipleFlushes(t *testing.T) {
+	var (
+		mu         sync.Mutex
+		keys       []string
+		batchSizes []int
+	)
+
+	b := batcher.New(
+		batcher.WithSkipAutoStart[test.BatchItem](),
+		batcher.WithBatchSize[test.BatchItem](2),
+		batcher.WithBatchInterval[test.BatchItem](20*time.Millisecond),
+		batcher.WithMaxQueueSize[test.BatchItem](2),
+		batcher.WithProcessor(func(items []test.BatchItem) error {
+			mu.Lock()
+			defer mu.Unlock()
+
+			batchSizes = append(batchSizes, len(items))
+			for _, item := range items {
+				keys = append(keys, item.Key)
+			}
+
+			return nil
+		}),
+	)
+	defer b.Close()
+
+	require.NoError(t, b.Enqueue(context.Background(), test.BatchItem{Key: "first"}))
+	require.NoError(t, b.Enqueue(context.Background(), test.BatchItem{Key: "second"}))
+
+	blockedDone := make(chan error, 1)
+	go func() {
+		blockedDone <- b.Enqueue(context.Background(), test.BatchItem{Key: "third"})
+	}()
+
+	select {
+	case err := <-blockedDone:
+		t.Fatalf("enqueue should have blocked, returned %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	b.Start()
+
+	select {
+	case err := <-blockedDone:
+		require.NoError(t, err)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for blocked enqueue to unblock")
+	}
+
+	require.NoError(t, b.Enqueue(context.Background(), test.BatchItem{Key: "fourth"}))
+	require.NoError(t, b.Enqueue(context.Background(), test.BatchItem{Key: "fifth"}))
+
+	require.NoError(t, b.Join(500*time.Millisecond))
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.Equal(t, []int{2, 2, 1}, batchSizes)
+	require.Equal(t, []string{"first", "second", "third", "fourth", "fifth"}, keys)
 }
 
 func TestLenReturnsToZeroAfterProcessorErrors(t *testing.T) {
@@ -317,6 +452,41 @@ func TestCloseFlushesPartialBatchAndIsIdempotent(t *testing.T) {
 	require.Equal(t, []string{"first", "second", "third"}, keys)
 }
 
+func TestCloseFlushesPartialBatchWithBoundedInput(t *testing.T) {
+	var (
+		mu   sync.Mutex
+		keys []string
+	)
+
+	b := batcher.New(
+		batcher.WithBatchSize[test.BatchItem](100),
+		batcher.WithBatchInterval[test.BatchItem](50*time.Millisecond),
+		batcher.WithMaxQueueSize[test.BatchItem](3),
+		batcher.WithProcessor(func(items []test.BatchItem) error {
+			mu.Lock()
+			defer mu.Unlock()
+
+			for _, item := range items {
+				keys = append(keys, item.Key)
+			}
+
+			return nil
+		}),
+	)
+
+	require.NoError(t, b.Enqueue(context.Background(), test.BatchItem{Key: "first"}))
+	require.NoError(t, b.Enqueue(context.Background(), test.BatchItem{Key: "second"}))
+	require.NoError(t, b.Enqueue(context.Background(), test.BatchItem{Key: "third"}))
+
+	require.NoError(t, b.Close())
+	require.Equal(t, 0, b.Len())
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.Equal(t, []string{"first", "second", "third"}, keys)
+}
+
 func TestEnqueueReturnsContextErrorWhenAlreadyCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -341,6 +511,37 @@ func TestEnqueueReturnsClosingErrorAfterClose(t *testing.T) {
 
 	require.ErrorIs(t, err, batcher.ErrClosing)
 	require.Equal(t, 0, b.Len())
+}
+
+func TestEnqueueReturnsClosingErrorWhenCloseStartsWhileWaiting(t *testing.T) {
+	b := batcher.New(
+		batcher.WithSkipAutoStart[test.BatchItem](),
+		batcher.WithBatchSize[test.BatchItem](10),
+		batcher.WithBatchInterval[test.BatchItem](10*time.Millisecond),
+		batcher.WithMaxQueueSize[test.BatchItem](1),
+	)
+
+	require.NoError(t, b.Enqueue(context.Background(), test.BatchItem{Key: "first"}))
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- b.Enqueue(context.Background(), test.BatchItem{Key: "second"})
+	}()
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("enqueue should have blocked, returned %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	require.ErrorIs(t, b.Close(), batcher.ErrTimeout)
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, batcher.ErrClosing)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for blocked enqueue to wake on close")
+	}
 }
 
 func TestAddSilentlyDropsAfterClose(t *testing.T) {

--- a/pkg/batcher/batcher_behavior_test.go
+++ b/pkg/batcher/batcher_behavior_test.go
@@ -69,6 +69,46 @@ func TestSkipAutoStartQueuesItemsUntilStart(t *testing.T) {
 	require.NoError(t, b.Close())
 }
 
+func TestSkipAutoStartQueuesItemsUntilStartWithBoundedInput(t *testing.T) {
+	processedCh := make(chan []test.BatchItem, 1)
+
+	b := batcher.New(
+		batcher.WithSkipAutoStart[test.BatchItem](),
+		batcher.WithBatchSize[test.BatchItem](10),
+		batcher.WithBatchInterval[test.BatchItem](20*time.Millisecond),
+		batcher.WithMaxQueueSize[test.BatchItem](2),
+		batcher.WithProcessor(func(items []test.BatchItem) error {
+			batchCopy := append([]test.BatchItem(nil), items...)
+			processedCh <- batchCopy
+
+			return nil
+		}),
+	)
+
+	require.NoError(t, b.Enqueue(context.Background(), test.BatchItem{Key: "first"}))
+	require.NoError(t, b.Enqueue(context.Background(), test.BatchItem{Key: "second"}))
+
+	select {
+	case batch := <-processedCh:
+		t.Fatalf("received batch before Start: %+v", batch)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	require.Equal(t, 2, b.Len())
+
+	b.Start()
+
+	select {
+	case batch := <-processedCh:
+		require.Equal(t, []test.BatchItem{{Key: "first"}, {Key: "second"}}, batch)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for queued items to process after Start")
+	}
+
+	require.NoError(t, b.Join(500*time.Millisecond))
+	require.NoError(t, b.Close())
+}
+
 func TestBatchIntervalStartsWhenFirstItemArrives(t *testing.T) {
 	processedCh := make(chan time.Time, 1)
 

--- a/pkg/batcher/batcher_behavior_test.go
+++ b/pkg/batcher/batcher_behavior_test.go
@@ -1,6 +1,7 @@
 package batcher_test
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -257,4 +258,42 @@ func TestCloseFlushesPartialBatchAndIsIdempotent(t *testing.T) {
 	defer mu.Unlock()
 
 	require.Equal(t, []string{"first", "second", "third"}, keys)
+}
+
+func TestEnqueueReturnsContextErrorWhenAlreadyCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	b := batcher.New[test.BatchItem]()
+	defer b.Close()
+
+	err := b.Enqueue(ctx, test.BatchItem{Key: "canceled"})
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 0, b.Len())
+}
+
+func TestEnqueueReturnsClosingErrorAfterClose(t *testing.T) {
+	b := batcher.New(
+		batcher.WithSkipAutoStart[test.BatchItem](),
+	)
+
+	require.NoError(t, b.Close())
+
+	err := b.Enqueue(context.Background(), test.BatchItem{Key: "late"})
+
+	require.ErrorIs(t, err, batcher.ErrClosing)
+	require.Equal(t, 0, b.Len())
+}
+
+func TestAddSilentlyDropsAfterClose(t *testing.T) {
+	b := batcher.New(
+		batcher.WithSkipAutoStart[test.BatchItem](),
+	)
+
+	require.NoError(t, b.Close())
+
+	b.Add(test.BatchItem{Key: "late"})
+
+	require.Equal(t, 0, b.Len())
 }

--- a/pkg/batcher/batcher_behavior_test.go
+++ b/pkg/batcher/batcher_behavior_test.go
@@ -265,6 +265,23 @@ func TestErrorsChannelClosesWhenBatcherStops(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 }
 
+func TestErrorsChannelClosesWhenBatcherStopsWithoutStart(t *testing.T) {
+	b := batcher.New(
+		batcher.WithSkipAutoStart[test.BatchItem](),
+	)
+
+	require.NoError(t, b.Close())
+
+	require.Eventually(t, func() bool {
+		select {
+		case _, ok := <-b.Errors():
+			return !ok
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestCloseFlushesPartialBatchAndIsIdempotent(t *testing.T) {
 	var (
 		mu   sync.Mutex

--- a/pkg/batcher/batcher_bench_test.go
+++ b/pkg/batcher/batcher_bench_test.go
@@ -13,34 +13,89 @@ type benchItem struct {
 	ID int
 }
 
+type benchmarkQueueMode struct {
+	name         string
+	maxQueueSize int
+}
+
+func benchmarkQueueModes(batchSize int) []benchmarkQueueMode {
+	return []benchmarkQueueMode{
+		{name: "unbounded"},
+		{name: "bounded_cap_" + strconv.Itoa(batchSize), maxQueueSize: batchSize},
+		{name: "bounded_cap_" + strconv.Itoa(batchSize*4), maxQueueSize: batchSize * 4},
+	}
+}
+
+func benchmarkLatencyQueueModes() []benchmarkQueueMode {
+	return []benchmarkQueueMode{
+		{name: "unbounded"},
+		{name: "bounded_cap_1", maxQueueSize: 1},
+		{name: "bounded_cap_8", maxQueueSize: 8},
+	}
+}
+
+func newBenchmarkBatcher(
+	processor batcher.Processor[benchItem],
+	batchSize int,
+	interval time.Duration,
+	mode benchmarkQueueMode,
+) *batcher.Batcher[benchItem] {
+	options := []batcher.Option[benchItem]{
+		batcher.WithProcessor(processor),
+		batcher.WithBatchSize[benchItem](batchSize),
+		batcher.WithBatchInterval[benchItem](interval),
+	}
+
+	if mode.maxQueueSize > 0 {
+		options = append(options, batcher.WithMaxQueueSize[benchItem](mode.maxQueueSize))
+	}
+
+	return batcher.New(options...)
+}
+
 func BenchmarkBatcherEnqueueOnly(b *testing.B) {
 	for _, batchSize := range []int{10, 100, 1000} {
-		b.Run("steady_high_volume_flushes_by_size_batch_"+strconv.Itoa(batchSize), func(b *testing.B) {
-			benchmarkEnqueueOnlySteadyLoad(b, batchSize)
-		})
+		for _, mode := range benchmarkQueueModes(batchSize) {
+			mode := mode
+			b.Run(mode.name+"/steady_high_volume_flushes_by_size_batch_"+strconv.Itoa(batchSize), func(b *testing.B) {
+				benchmarkEnqueueOnlySteadyLoad(b, batchSize, mode)
+			})
+		}
 	}
 }
 
 func BenchmarkBatcherEndToEnd(b *testing.B) {
 	for _, batchSize := range []int{10, 100, 1000} {
-		b.Run("steady_high_volume_processes_full_batch_of_"+strconv.Itoa(batchSize), func(b *testing.B) {
-			benchmarkEndToEndSizeFlush(b, batchSize)
+		for _, mode := range benchmarkQueueModes(batchSize) {
+			mode := mode
+			b.Run(mode.name+"/steady_high_volume_processes_full_batch_of_"+strconv.Itoa(batchSize), func(b *testing.B) {
+				benchmarkEndToEndSizeFlush(b, batchSize, mode)
+			})
+		}
+	}
+
+	for _, mode := range benchmarkQueueModes(100) {
+		mode := mode
+		b.Run(mode.name+"/burst_of_1000_items_drains_in_batches_of_100", func(b *testing.B) {
+			benchmarkBurstDrain(b, 1000, 100, mode)
 		})
 	}
 
-	b.Run("burst_of_1000_items_drains_in_batches_of_100", func(b *testing.B) {
-		benchmarkBurstDrain(b, 1000, 100)
-	})
-
-	b.Run("sparse_trickle_flushes_single_item_on_interval", func(b *testing.B) {
-		benchmarkEndToEndIntervalFlush(b, 2*time.Millisecond)
-	})
+	for _, mode := range benchmarkQueueModes(1000) {
+		mode := mode
+		b.Run(mode.name+"/sparse_trickle_flushes_single_item_on_interval", func(b *testing.B) {
+			benchmarkEndToEndIntervalFlush(b, 2*time.Millisecond, mode)
+		})
+	}
 }
 
 func BenchmarkBatcherShutdown(b *testing.B) {
-	b.Run("service_shutdown_drains_partial_batch_before_exit", func(b *testing.B) {
-		benchmarkShutdownFlush(b, 25, 100, 5*time.Millisecond)
-	})
+	for _, mode := range benchmarkQueueModes(100) {
+		mode := mode
+		b.Run(mode.name+"/service_shutdown_drains_partial_batch_before_exit", func(b *testing.B) {
+			benchmarkShutdownFlush(b, 25, 100, 5*time.Millisecond, mode)
+		})
+	}
 }
 
 // BenchmarkBatcherConcurrentProducers covers the dominant production usage:
@@ -49,24 +104,28 @@ func BenchmarkBatcherShutdown(b *testing.B) {
 // batchInputChan and shows per-Add latency under GOMAXPROCS-way concurrency.
 func BenchmarkBatcherConcurrentProducers(b *testing.B) {
 	for _, batchSize := range []int{10, 100, 1000} {
-		b.Run("many_producers_flush_by_size_batch_"+strconv.Itoa(batchSize), func(b *testing.B) {
-			benchmarkConcurrentProducers(b, batchSize)
-		})
+		for _, mode := range benchmarkQueueModes(batchSize) {
+			mode := mode
+			b.Run(mode.name+"/many_producers_flush_by_size_batch_"+strconv.Itoa(batchSize), func(b *testing.B) {
+				benchmarkConcurrentProducers(b, batchSize, mode)
+			})
+		}
 	}
 }
 
-func benchmarkConcurrentProducers(b *testing.B, batchSize int) {
+func benchmarkConcurrentProducers(b *testing.B, batchSize int, mode benchmarkQueueMode) {
 	b.ReportAllocs()
 
 	var processed atomic.Int64
 
-	batch := batcher.New(
-		batcher.WithProcessor(func(items []benchItem) error {
+	batch := newBenchmarkBatcher(
+		func(items []benchItem) error {
 			processed.Add(int64(len(items)))
 			return nil
-		}),
-		batcher.WithBatchSize[benchItem](batchSize),
-		batcher.WithBatchInterval[benchItem](time.Second),
+		},
+		batchSize,
+		time.Second,
+		mode,
 	)
 	b.Cleanup(func() {
 		if err := batch.Close(); err != nil {
@@ -99,54 +158,61 @@ func benchmarkConcurrentProducers(b *testing.B, batchSize int) {
 // emits one item at a time and waits for the batch to be processed, modeling
 // low-traffic request-scoped use where every Add pays the full round-trip.
 func BenchmarkBatcherSingleItemLatency(b *testing.B) {
-	b.ReportAllocs()
+	for _, mode := range benchmarkLatencyQueueModes() {
+		mode := mode
+		b.Run(mode.name+"/one_item_per_request_round_trip", func(b *testing.B) {
+			b.ReportAllocs()
 
-	processed := make(chan int, 1)
+			processed := make(chan int, 1)
 
-	batch := batcher.New(
-		batcher.WithProcessor(func(items []benchItem) error {
-			processed <- len(items)
-			return nil
-		}),
-		batcher.WithBatchSize[benchItem](1),
-		batcher.WithBatchInterval[benchItem](time.Second),
-	)
-	b.Cleanup(func() {
-		if err := batch.Close(); err != nil {
-			b.Fatalf("close error: %v", err)
-		}
-	})
+			batch := newBenchmarkBatcher(
+				func(items []benchItem) error {
+					processed <- len(items)
+					return nil
+				},
+				1,
+				time.Second,
+				mode,
+			)
+			b.Cleanup(func() {
+				if err := batch.Close(); err != nil {
+					b.Fatalf("close error: %v", err)
+				}
+			})
 
-	b.ResetTimer()
+			b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
-		batch.Add(benchItem{ID: i})
-		if got := <-processed; got != 1 {
-			b.Fatalf("processed batch size %d, want 1", got)
-		}
+			for i := 0; i < b.N; i++ {
+				batch.Add(benchItem{ID: i})
+				if got := <-processed; got != 1 {
+					b.Fatalf("processed batch size %d, want 1", got)
+				}
+			}
+
+			b.StopTimer()
+
+			if err := batch.Join(10 * time.Second); err != nil {
+				b.Fatalf("join error: %v", err)
+			}
+
+			b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "items/s")
+		})
 	}
-
-	b.StopTimer()
-
-	if err := batch.Join(10 * time.Second); err != nil {
-		b.Fatalf("join error: %v", err)
-	}
-
-	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "items/s")
 }
 
-func benchmarkEnqueueOnlySteadyLoad(b *testing.B, batchSize int) {
+func benchmarkEnqueueOnlySteadyLoad(b *testing.B, batchSize int, mode benchmarkQueueMode) {
 	b.ReportAllocs()
 
 	var processed atomic.Int64
 
-	batch := batcher.New(
-		batcher.WithProcessor(func(items []benchItem) error {
+	batch := newBenchmarkBatcher(
+		func(items []benchItem) error {
 			processed.Add(int64(len(items)))
 			return nil
-		}),
-		batcher.WithBatchSize[benchItem](batchSize),
-		batcher.WithBatchInterval[benchItem](time.Second),
+		},
+		batchSize,
+		time.Second,
+		mode,
 	)
 	b.Cleanup(func() {
 		if err := batch.Close(); err != nil {
@@ -173,18 +239,19 @@ func benchmarkEnqueueOnlySteadyLoad(b *testing.B, batchSize int) {
 	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "items/s")
 }
 
-func benchmarkEndToEndSizeFlush(b *testing.B, batchSize int) {
+func benchmarkEndToEndSizeFlush(b *testing.B, batchSize int, mode benchmarkQueueMode) {
 	b.ReportAllocs()
 
 	processed := make(chan int, 1)
 
-	batch := batcher.New(
-		batcher.WithProcessor(func(items []benchItem) error {
+	batch := newBenchmarkBatcher(
+		func(items []benchItem) error {
 			processed <- len(items)
 			return nil
-		}),
-		batcher.WithBatchSize[benchItem](batchSize),
-		batcher.WithBatchInterval[benchItem](time.Second),
+		},
+		batchSize,
+		time.Second,
+		mode,
 	)
 	b.Cleanup(func() {
 		if err := batch.Close(); err != nil {
@@ -221,18 +288,19 @@ func benchmarkEndToEndSizeFlush(b *testing.B, batchSize int) {
 	b.ReportMetric(float64(totalItems)/b.Elapsed().Seconds(), "items/s")
 }
 
-func benchmarkEndToEndIntervalFlush(b *testing.B, interval time.Duration) {
+func benchmarkEndToEndIntervalFlush(b *testing.B, interval time.Duration, mode benchmarkQueueMode) {
 	b.ReportAllocs()
 
 	processed := make(chan int, 1)
 
-	batch := batcher.New(
-		batcher.WithProcessor(func(items []benchItem) error {
+	batch := newBenchmarkBatcher(
+		func(items []benchItem) error {
 			processed <- len(items)
 			return nil
-		}),
-		batcher.WithBatchSize[benchItem](1000),
-		batcher.WithBatchInterval[benchItem](interval),
+		},
+		1000,
+		interval,
+		mode,
 	)
 	b.Cleanup(func() {
 		if err := batch.Close(); err != nil {
@@ -259,18 +327,19 @@ func benchmarkEndToEndIntervalFlush(b *testing.B, interval time.Duration) {
 	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "items/s")
 }
 
-func benchmarkBurstDrain(b *testing.B, burstSize int, batchSize int) {
+func benchmarkBurstDrain(b *testing.B, burstSize int, batchSize int, mode benchmarkQueueMode) {
 	b.ReportAllocs()
 
 	processed := make(chan int, burstSize/batchSize+1)
 
-	batch := batcher.New(
-		batcher.WithProcessor(func(items []benchItem) error {
+	batch := newBenchmarkBatcher(
+		func(items []benchItem) error {
 			processed <- len(items)
 			return nil
-		}),
-		batcher.WithBatchSize[benchItem](batchSize),
-		batcher.WithBatchInterval[benchItem](time.Second),
+		},
+		batchSize,
+		time.Second,
+		mode,
 	)
 	b.Cleanup(func() {
 		if err := batch.Close(); err != nil {
@@ -303,7 +372,13 @@ func benchmarkBurstDrain(b *testing.B, burstSize int, batchSize int) {
 	b.ReportMetric(float64(b.N*burstSize)/b.Elapsed().Seconds(), "items/s")
 }
 
-func benchmarkShutdownFlush(b *testing.B, pendingItems int, batchSize int, interval time.Duration) {
+func benchmarkShutdownFlush(
+	b *testing.B,
+	pendingItems int,
+	batchSize int,
+	interval time.Duration,
+	mode benchmarkQueueMode,
+) {
 	b.ReportAllocs()
 
 	totalItems := 0
@@ -312,13 +387,14 @@ func benchmarkShutdownFlush(b *testing.B, pendingItems int, batchSize int, inter
 	for i := 0; i < b.N; i++ {
 		processed := make(chan int, 1)
 
-		batch := batcher.New(
-			batcher.WithProcessor(func(items []benchItem) error {
+		batch := newBenchmarkBatcher(
+			func(items []benchItem) error {
 				processed <- len(items)
 				return nil
-			}),
-			batcher.WithBatchSize[benchItem](batchSize),
-			batcher.WithBatchInterval[benchItem](interval),
+			},
+			batchSize,
+			interval,
+			mode,
 		)
 
 		b.StartTimer()

--- a/pkg/batcher/batcher_test.go
+++ b/pkg/batcher/batcher_test.go
@@ -25,6 +25,7 @@ func TestCanCreateBatcherWithDefaultConfig(t *testing.T) {
 	require.NotNil(t, b)
 	require.Equal(t, batcher.DefaultBatchSize, b.Config().BatchSize)
 	require.Equal(t, batcher.DefaultBatchInterval, b.Config().BatchInterval)
+	require.Zero(t, b.Config().MaxQueueSize)
 
 	expected = batcher.NoOpProcessor[test.BatchItem]
 	actual = b.Config().ProcessorFunc
@@ -42,12 +43,14 @@ func TestCanCreateBatcher(t *testing.T) {
 		batcher.WithProcessor(noop),
 		batcher.WithBatchSize[test.BatchItem](1000),
 		batcher.WithBatchInterval[test.BatchItem](1*time.Second),
+		batcher.WithMaxQueueSize[test.BatchItem](42),
 	)
 
 	// ASSERT
 	require.NotNil(t, b)
 	require.Equal(t, 1000, b.Config().BatchSize)
 	require.Equal(t, 1*time.Second, b.Config().BatchInterval)
+	require.Equal(t, 42, b.Config().MaxQueueSize)
 }
 
 func TestCanAddItemsToBatch(t *testing.T) {

--- a/pkg/batcher/fx.go
+++ b/pkg/batcher/fx.go
@@ -11,6 +11,7 @@ func ProvideBatcherInFX[T any](
 	processorFactory any,
 	batchSize int,
 	batchInterval time.Duration,
+	maxQueueSize int,
 ) fx.Option {
 	return fx.Module(
 		"batcher",
@@ -24,6 +25,7 @@ func ProvideBatcherInFX[T any](
 					WithProcessor(processorFunc),
 					WithBatchSize[T](batchSize),
 					WithBatchInterval[T](batchInterval),
+					WithMaxQueueSize[T](maxQueueSize),
 					WithSkipAutoStart[T](),
 				)
 

--- a/pkg/batcher/fx_readme_test.go
+++ b/pkg/batcher/fx_readme_test.go
@@ -49,6 +49,7 @@ func TestREADMEExample(t *testing.T) {
 			},
 			2,                    // batch size
 			time.Millisecond*100, // batch interval
+			0,                    // max queue size (unbounded)
 		),
 		// Provide the request handler
 		fx.Provide(NewRequestHandler),

--- a/pkg/batcher/fx_test.go
+++ b/pkg/batcher/fx_test.go
@@ -47,6 +47,7 @@ func TestProvideBatcherInFX(t *testing.T) {
 			},
 			2,                    // batch size
 			time.Millisecond*100, // batch interval
+			0,                    // max queue size (unbounded)
 		),
 		fx.Populate(&b, &p), // Populate the batcher variable
 	)
@@ -54,6 +55,7 @@ func TestProvideBatcherInFX(t *testing.T) {
 	// Start the app
 	app.RequireStart()
 	require.NotNil(t, b, "batcher should be populated")
+	require.Zero(t, b.Config().MaxQueueSize)
 
 	// Add some items to the batcher
 	b.Add(&BatchItem{ID: 1, Name: "item1"})
@@ -86,12 +88,14 @@ func TestProvideBatcherInFXStopFlushesPartialBatch(t *testing.T) {
 			},
 			10,
 			30*time.Millisecond,
+			64,
 		),
 		fx.Populate(&b, &p),
 	)
 
 	app.RequireStart()
 	require.NotNil(t, b, "batcher should be populated")
+	require.Equal(t, 64, b.Config().MaxQueueSize)
 
 	b.Add(&BatchItem{ID: 1, Name: "item1"})
 	b.Add(&BatchItem{ID: 2, Name: "item2"})

--- a/pkg/batcher/goroutine_leak_test.go
+++ b/pkg/batcher/goroutine_leak_test.go
@@ -1,6 +1,7 @@
 package batcher_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"runtime"
@@ -131,6 +132,59 @@ func TestBatcher_StopWithPendingMessages(t *testing.T) {
 			currentGoroutines := runtime.NumGoroutine()
 			if currentGoroutines <= startGoroutines+2 {
 				t.Logf("✅ All goroutines cleaned up successfully")
+				return
+			}
+		}
+	}
+}
+
+// TestBatcher_BlockedProducerUnblocksOnClose covers the bounded-queue case where
+// a producer goroutine is waiting for capacity when shutdown begins.
+func TestBatcher_BlockedProducerUnblocksOnClose(t *testing.T) {
+	initialGoroutines := runtime.NumGoroutine()
+
+	b := batcher.New(
+		batcher.WithSkipAutoStart[string](),
+		batcher.WithBatchSize[string](10),
+		batcher.WithBatchInterval[string](10*time.Millisecond),
+		batcher.WithMaxQueueSize[string](1),
+	)
+
+	require.NoError(t, b.Enqueue(context.Background(), "first"))
+
+	producerDone := make(chan struct{})
+	go func() {
+		defer close(producerDone)
+		b.Add("second")
+	}()
+
+	select {
+	case <-producerDone:
+		t.Fatal("producer should have blocked on full bounded queue")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	require.ErrorIs(t, b.Close(), batcher.ErrTimeout)
+
+	select {
+	case <-producerDone:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("blocked producer did not unblock after Close")
+	}
+
+	timeout := time.After(5 * time.Second)
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeout:
+			currentGoroutines := runtime.NumGoroutine()
+			t.Fatalf("goroutine cleanup failed: started with %d, still have %d after blocked producer shutdown",
+				initialGoroutines, currentGoroutines)
+		case <-ticker.C:
+			currentGoroutines := runtime.NumGoroutine()
+			if currentGoroutines <= initialGoroutines+2 {
 				return
 			}
 		}

--- a/pkg/batcher/options.go
+++ b/pkg/batcher/options.go
@@ -35,6 +35,18 @@ func WithBatchInterval[T any](batchInterval time.Duration) Option[T] {
 	}
 }
 
+// WithMaxQueueSize sets the maximum queue size.
+// A value less than or equal to zero keeps the queue unbounded.
+func WithMaxQueueSize[T any](maxQueueSize int) Option[T] {
+	return func(b *Batcher[T]) {
+		if maxQueueSize <= 0 {
+			maxQueueSize = 0
+		}
+
+		b.config.MaxQueueSize = maxQueueSize
+	}
+}
+
 // WithSkipAutoStart skips the automatic start of the batcher.
 func WithSkipAutoStart[T any]() Option[T] {
 	return func(b *Batcher[T]) {

--- a/pkg/batcher/options_test.go
+++ b/pkg/batcher/options_test.go
@@ -74,3 +74,36 @@ func TestWithBatchInterval(t *testing.T) {
 		require.Equal(t, batcher.DefaultBatchInterval, b.Config().BatchInterval)
 	})
 }
+
+func TestWithMaxQueueSize(t *testing.T) {
+	// ARRANGE
+	b := batcher.New[test.BatchItem]()
+
+	// ACT
+	batcher.WithMaxQueueSize[test.BatchItem](128)(b)
+
+	// ASSERT
+	require.Equal(t, 128, b.Config().MaxQueueSize)
+
+	t.Run("WithMaxQueueSize - zero keeps unbounded", func(t *testing.T) {
+		// ARRANGE
+		b := batcher.New[test.BatchItem]()
+
+		// ACT
+		batcher.WithMaxQueueSize[test.BatchItem](0)(b)
+
+		// ASSERT
+		require.Equal(t, 0, b.Config().MaxQueueSize)
+	})
+
+	t.Run("WithMaxQueueSize - negative keeps unbounded", func(t *testing.T) {
+		// ARRANGE
+		b := batcher.New[test.BatchItem]()
+
+		// ACT
+		batcher.WithMaxQueueSize[test.BatchItem](-10)(b)
+
+		// ASSERT
+		require.Equal(t, 0, b.Config().MaxQueueSize)
+	})
+}


### PR DESCRIPTION
## Summary
- add `WithMaxQueueSize` and `Enqueue(ctx, item)` so callers can opt into bounded admission with explicit backpressure and shutdown-aware enqueue behavior while keeping `Add` as the convenience API
- use a native buffered channel for bounded mode and harden shutdown so blocked producers wake cleanly, accepted items still drain, and close remains idempotent
- add extensive bounded-behavior tests, bounded-vs-unbounded scenario benchmarks, and README/docs updates that explain blocking, unblocking, close-time behavior, Kafka-style usage, and FX wiring

## Test plan
- [x] `go test ./...`
- [x] `go test ./pkg/batcher -run '^$' -bench 'BenchmarkBatcher' -benchtime=100ms`

## Benchmark notes
- On the local `darwin/arm64` pass, bounded mode was consistently faster than the current unbounded path in enqueue-only and full-batch end-to-end scenarios.
- Concurrent-producer throughput also improved versus unbounded mode, especially with roomier caps, while sparse interval-driven flushes stayed roughly neutral.
- The new suite keeps bounded and unbounded measurements in the same scenario families so reruns can compare queue modes directly instead of relying on unrelated one-off benchmarks.